### PR TITLE
Add Stripe needed data for new Pay Element

### DIFF
--- a/src/NoFrixion.MoneyMoov/Models/PaymentRequests/PaymentRequestMinimal.cs
+++ b/src/NoFrixion.MoneyMoov/Models/PaymentRequests/PaymentRequestMinimal.cs
@@ -48,4 +48,8 @@ public class PaymentRequestMinimal
     /// </summary>
     [JsonConverter(typeof(StringEnumConverter))]
     public PaymentProcessorsEnum PaymentProcessor { get; set; }
+
+    public string? CallbackUrl { get; set; }
+
+    public string? CardStripePaymentIntentSecret { get; set; }
 }


### PR DESCRIPTION
Added `CallbackUrl` & `CardStripePaymentIntentSecret` to `PaymentRequestMinimal` as it was needed for the Stripe Integration for the new Pay Element