### PR TITLE
Incorrect outstanding amount in case of PISP authorized status

### DIFF
--- a/src/NoFrixion.MoneyMoov/Models/PaymentRequests/PaymentRequestResult.cs
+++ b/src/NoFrixion.MoneyMoov/Models/PaymentRequests/PaymentRequestResult.cs
@@ -139,7 +139,8 @@ public class PaymentRequestResult
                 {
                     // Successfully authorised payment initiation.
                     if (!string.IsNullOrEmpty(payEvent.PispPaymentInitiationID) && !PispAuthorizations.Any(
-                            x => x.PispPaymentInitiationID == payEvent.PispPaymentInitiationID))
+                            x => x.PispPaymentInitiationID == payEvent.PispPaymentInitiationID)
+                        && payEvent.Amount != decimal.Zero)
                     {
                         PispAuthorizations.Add(
                             new PaymentRequestAuthorization


### PR DESCRIPTION
Aaron tried a full PISP payment on production and the status was set to Authorized. In this case, it should have redirected to result page when the payment link is opened again. But it loaded the payelement instead. This was caused because of incorrect outstanding amount calculation. The Yapily webhook event logged had amount as 0. Turns out we were not logging the amount for PIS webhooks.

In this change, I am considering events with amount > 0 only. Although, I have made changes in the event logging to log the amount as well.