### PR TITLE
[MOOV-1617]: Added Personal and Business Bank Institution IDs

### DIFF
--- a/src/NoFrixion.MoneyMoov/Models/Merchant/MerchantPayByBankSetting.cs
+++ b/src/NoFrixion.MoneyMoov/Models/Merchant/MerchantPayByBankSetting.cs
@@ -57,14 +57,12 @@ public class MerchantPayByBankSetting
     public string? Processor { get; set; }
 
     /// <summary>
-    /// ID that the processor uses to identify the bank.
+    /// ID that the processor uses to identify the bank (personal accounts).
     /// </summary>
-    public string? ProviderID { get; set; }
+    public string? PersonalInstitutionID { get; set; }
 
     /// <summary>
-    /// Whether the bank supports Personal or Business type accounts.
+    /// ID that the processor uses to identify the bank (business accounts).
     /// </summary>
-    [EnumDataType(typeof(BankAccountTypeEnum))]
-    [JsonConverter(typeof(StringEnumConverter))]
-    public BankAccountTypeEnum AccountType { get; set; }
+    public string? BusinessInstitutionID { get; set; }
 }


### PR DESCRIPTION
Removed Feature, ProviderID and AccountType properties from the PayByBankSettings and added PersonalInstitutionID and BusinessInstitutionID fields for the next-gen PayElement.