### PR TITLE
[MOOV-1624]: Added bank message image field for the PayElement

### DIFF
--- a/src/NoFrixion.MoneyMoov/Models/Merchant/MerchantPayByBankSetting.cs
+++ b/src/NoFrixion.MoneyMoov/Models/Merchant/MerchantPayByBankSetting.cs
@@ -70,4 +70,9 @@ public class MerchantPayByBankSetting
     /// Message relating to specific bank.  
     /// </summary>
     public string? Message { get; set; }
+
+    /// <summary>
+    /// Optional image URL to be displayed with the message.
+    /// </summary>
+    public string? MessageImageUrl { get; set; }
 }


### PR DESCRIPTION
Added a bank message image URL field to be used when displaying a bank option on the PayElement.