### PR TITLE
Fixed regexes for payment request update

### DIFF
--- a/src/NoFrixion.MoneyMoov/Constants/PaymentRequestConstants.cs
+++ b/src/NoFrixion.MoneyMoov/Constants/PaymentRequestConstants.cs
@@ -21,12 +21,12 @@ public class PaymentRequestConstants
     public const string DESCRIPTION_ERROR_MESSAGE =
         @"The Description can only contain alphanumeric characters and -_.@&*%$#!:;'"" and space.";
 
-    public const string CUSTOMER_ID_CHARS_REGEX = @"[a-zA-Z0-9-]+";
+    public const string CUSTOMER_ID_CHARS_REGEX = @"[a-zA-Z0-9\-]+";
 
     public const string CUSTOMER_ID_ERROR_MESSAGE =
         @"The CustomerID can only contain alphanumeric characters and dash.";
 
-    public const string ORDER_ID_CHARS_REGEX = @"[a-zA-Z0-9-_\.@&\*%\$#!:; ]+";
+    public const string ORDER_ID_CHARS_REGEX = @"[a-zA-Z0-9\-_\.@&\*%\$#!:; ]+";
 
     public const string ORDER_ID_ERROR_MESSAGE =
         @"The OrderID can only contain alphanumeric characters and -_.@&*%$#!:; and space.";


### PR DESCRIPTION
The hyphens do not need to be escaped in these two cases. BUT we've had bugs introduced when characters have been added that turn the - into a range and then it does need to be escaped. This was the same bug we had on the identity server and special password chars.

Rule is always escape - as \- if it's being used to match a single char.
