### PR TITLE
Remove spaces when setting account identifier fields.

### DIFF
--- a/src/NoFrixion.MoneyMoov/Extensions/PaymentRequestExtensions.cs
+++ b/src/NoFrixion.MoneyMoov/Extensions/PaymentRequestExtensions.cs
@@ -189,7 +189,7 @@ public static class PaymentRequestExtensions
         foreach (var attempt in pispAttempts)
         {
             // The pisp_initiate event should always be present but if for some reason it's not the next best event
-            // will be sued as the starting point for he attempt.
+            // will be sued as the starting point for the attempt.
             var initiateEvent =
                 attempt.Where(x => x.EventType == PaymentRequestEventTypesEnum.pisp_initiate).FirstOrDefault() ??
                 attempt.Where(x => x.EventType == PaymentRequestEventTypesEnum.pisp_callback).FirstOrDefault() ??

--- a/src/NoFrixion.MoneyMoov/Models/Account/AccountIdentifier.cs
+++ b/src/NoFrixion.MoneyMoov/Models/Account/AccountIdentifier.cs
@@ -12,8 +12,6 @@
 //  MIT.
 // -----------------------------------------------------------------------------
 
-using System.ComponentModel.DataAnnotations;
-
 namespace NoFrixion.MoneyMoov.Models;
 
 #nullable disable
@@ -51,24 +49,83 @@ public class AccountIdentifier
     /// <summary>
     /// The Bank Identifier Code for an IBAN.
     /// </summary>
-    public string BIC { get; set; }
+    private string _bic;
+    public string BIC
+    {
+        get => _bic;
+        set
+        {
+            if (!string.IsNullOrEmpty(value))
+            {
+                _bic = value.Trim().Replace(" ", string.Empty);
+            }
+            else
+            {
+                _bic = value;
+            }
+        }
+    }
 
     /// <summary>
     /// The International Bank Account Number for the identifier. Only applicable 
     /// for IBAN identifiers.
     /// </summary>
-    public string IBAN { get; set; }
+    private string _iban;
+    public string IBAN 
+    {
+        get => _iban;
+        set
+        {
+            if (!string.IsNullOrEmpty(value))
+            {
+                _iban = value.Trim().Replace(" ", string.Empty);
+            }
+            else
+            {
+                _iban = value;
+            }
+        }
+    }
 
     /// <summary>
     /// The account Sort Code. Only applicable for SCAN identifiers.
     /// </summary>
-    public string SortCode { get; set; }
+    private string _sortCode;
+    public string SortCode
+    {
+        get => _sortCode;
+        set
+        {
+            if (!string.IsNullOrEmpty(value))
+            {
+                _sortCode = value.Trim().Replace(" ", string.Empty);
+            }
+            else
+            {
+                _sortCode = value;
+            }
+        }
+    }
 
     /// <summary>
     /// Bank account number. Only applicable for SCAN identifiers.
     /// </summary>
-    public string AccountNumber { get; set; }
-
+    private string _accountNumber;
+    public string AccountNumber
+    {
+        get => _accountNumber;
+        set
+        {
+            if (!string.IsNullOrEmpty(value))
+            {
+                _accountNumber = value.Trim().Replace(" ", string.Empty);
+            }
+            else
+            {
+                _accountNumber = value;
+            }
+        }
+    }
     /// <summary>
     /// Summary of the account identifier's most important properties.
     /// </summary>

--- a/test/MoneyMoov.UnitTests/Models/AccountIdentifierTests.cs
+++ b/test/MoneyMoov.UnitTests/Models/AccountIdentifierTests.cs
@@ -1,0 +1,65 @@
+//-----------------------------------------------------------------------------
+// Filename: AccountIdentifierTests.cs
+//
+// Description: Unit tests for the MoneyMoov AccountIdentifier model.
+//
+// Author(s):
+// Aaron Clauson (aaron@nofrixion.com)
+// 
+// History:
+// 30 Jun 2023  Aaron Clauson   Created, Harcourt St, Dublin, Ireland.
+//
+// License: 
+// MIT.
+//-----------------------------------------------------------------------------
+
+using Microsoft.Extensions.Logging;
+using NoFrixion.MoneyMoov.Models;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace NoFrixion.MoneyMoov.UnitTests;
+
+public class AccountIdentifierTests : MoneyMoovUnitTestBase<AccountIdentifierTests>
+{
+    public AccountIdentifierTests(ITestOutputHelper testOutputHelper) : base(testOutputHelper)
+    { }
+
+    /// <summary>
+    /// Tests that spaces are removed from the BIC and IBAN when creating an account identifier.
+    /// </summary>
+    [Fact]
+    public void AccountIdentifier_Create_IBAN_Spaces_Success()
+    {
+        Logger.LogDebug($"--> {TypeExtensions.GetCaller()}.");
+
+        var accountIdentifier = new AccountIdentifier
+        {
+            BIC = "  MODR  123 ",
+            IBAN = " GB42MO CK00000070629 907 "
+        };
+
+        Assert.Equal(AccountIdentifierType.IBAN, accountIdentifier.Type);
+        Assert.Equal("MODR123", accountIdentifier.BIC);
+        Assert.Equal("GB42MOCK00000070629907", accountIdentifier.IBAN);
+    }
+
+    /// <summary>
+    /// Tests that spaces are removed from the Sort Code and Account Number when creating an account identifier.
+    /// </summary>
+    [Fact]
+    public void AccountIdentifier_Create_SCAN_Spaces_Success()
+    {
+        Logger.LogDebug($"--> {TypeExtensions.GetCaller()}.");
+
+        var accountIdentifier = new AccountIdentifier
+        {
+            SortCode = " 12 34 56 ",
+            AccountNumber = " 00000070629 907 "
+        };
+
+        Assert.Equal(AccountIdentifierType.SCAN, accountIdentifier.Type);
+        Assert.Equal("123456", accountIdentifier.SortCode);
+        Assert.Equal("00000070629907", accountIdentifier.AccountNumber);
+    }
+}


### PR DESCRIPTION
IBANs, BICs etc don't needs paces and can cause porblems with upstream suppliers, This PR removes any spaces when setting those values.