### PR TITLE
Using card payment attempts in Payment Request result

### DIFF
--- a/src/NoFrixion.MoneyMoov/Extensions/PaymentRequestEventExtensions.cs
+++ b/src/NoFrixion.MoneyMoov/Extensions/PaymentRequestEventExtensions.cs
@@ -1,0 +1,280 @@
+﻿// -----------------------------------------------------------------------------
+//  Filename: PaymentRequestEventExtensions.cs
+// 
+//  Description: Extension methods for PaymentRequestEvent model
+// 
+//  Author(s):
+//  Saurav Maiti (saurav@nofrixion.com)
+// 
+//  History:
+//  21 07 2023  Saurav Maiti Created, Harcourt Street, Dublin, Ireland.
+// 
+//  License:
+//  Proprietary NoFrixion.
+// -----------------------------------------------------------------------------
+
+
+using NoFrixion.MoneyMoov.Models;
+
+namespace NoFrixion.MoneyMoov.Extensions;
+
+public static class PaymentRequestEventExtensions
+{
+    /// <summary>
+    /// Sets the payment attempt card properties from a grouping of card events.
+    /// This method takes care of setting card authorisation specific properties in payment attempt.
+    /// </summary>
+    /// <param name="groupedCardEvents">A set of card payment events with the same CardAuthorisationResponseID.</param>
+    /// <param name="paymentAttempt">The payment attempt object in which the authorisation properties are to be set.</param>
+    /// <exception cref="ArgumentNullException"></exception>
+    public static void HandleCardAuthorisationEvents(this IGrouping<string?, PaymentRequestEvent> groupedCardEvents,
+        PaymentRequestPaymentAttempt paymentAttempt)
+    {
+        if (paymentAttempt == null) throw new ArgumentNullException(nameof(paymentAttempt));
+
+        if (groupedCardEvents.All(x => x.EventType != PaymentRequestEventTypesEnum.card_authorization))
+        {
+            return;
+        }
+
+        var cardAuthorizationEvent =
+            groupedCardEvents.First(x => x.EventType == PaymentRequestEventTypesEnum.card_authorization);
+
+        // The CardAuthorizationResponseID is NULL for card_payer_authentication_setup events.
+        var cardAuthorizationSetupEvent = groupedCardEvents.FirstOrDefault(x =>
+            x.EventType == PaymentRequestEventTypesEnum.card_payer_authentication_setup
+            && x.CardRequestID == cardAuthorizationEvent.CardRequestID);
+
+
+        var initialEvent = cardAuthorizationSetupEvent ?? cardAuthorizationEvent;
+        paymentAttempt.AttemptKey = groupedCardEvents.Key ?? string.Empty;
+        paymentAttempt.PaymentRequestID = initialEvent.PaymentRequestID;
+        paymentAttempt.InitiatedAt = initialEvent.Inserted;
+        paymentAttempt.PaymentMethod = PaymentMethodTypeEnum.card;
+        paymentAttempt.Currency = initialEvent.Currency;
+        paymentAttempt.AttemptedAmount = cardAuthorizationEvent.Amount;
+        paymentAttempt.PaymentProcessor = initialEvent.PaymentProcessorName;
+        paymentAttempt.TokenisedCardID = cardAuthorizationEvent.TokenisedCardID?.ToString();
+
+        var isSuccessfullAuthorisationEvent = cardAuthorizationEvent.IsSuccessfulCardAuthorisationEvent();
+
+
+        // If the card authorization event was successful, then the payment attempt was authorised.
+        if (!isSuccessfullAuthorisationEvent)
+        {
+            return;
+        }
+
+        paymentAttempt.CardAuthorisedAt = cardAuthorizationEvent.Inserted;
+        
+        paymentAttempt.CardAuthorisedAmount = cardAuthorizationEvent.Amount;
+
+    }
+
+    public static void HandleCardCaptureEvents(this IGrouping<string?, PaymentRequestEvent> groupedCardEvents,
+        PaymentRequestPaymentAttempt paymentAttempt)
+    {
+        var cardCaptureEvents = groupedCardEvents.GetAllCardCaptureEvents();
+
+        if (!cardCaptureEvents.Any())
+        {
+            return;
+        }
+
+        foreach (var cardCaptureEvent in cardCaptureEvents)
+        {
+            // Successful capture events are added to the capture attempts list.
+            if (cardCaptureEvent.IsSuccessfulCardCaptureOrSaleEvent())
+            {
+                paymentAttempt.CaptureAttempts.AddRange(new[]
+                {
+                    new PaymentRequestCaptureAttempt
+                        { CapturedAt = cardCaptureEvent.Inserted, CapturedAmount = cardCaptureEvent.Amount }
+                });
+            }
+            else
+            {
+                // Failed capture events are added to the capture attempts list.
+                paymentAttempt.CaptureAttempts.AddRange(new[]
+                {
+                    new PaymentRequestCaptureAttempt
+                    {
+                        CaptureFailedAt = cardCaptureEvent.Inserted, CaptureFailureError = cardCaptureEvent.ErrorMessage
+                    }
+                });
+            }
+        }
+    }
+
+    public static void HandleCardSaleEvents(this IGrouping<string?, PaymentRequestEvent> groupedCardEvent,
+        PaymentRequestPaymentAttempt paymentAttempt)
+    {
+        var cardSaleEvents = groupedCardEvent.GetAllCardSaleEvents();
+
+        if (!cardSaleEvents.Any())
+        {
+            return;
+        }
+
+        // This is done because in some cases the card authorise event may not be present
+        // and card sale event is the first event. In such cases, the payment attempt is
+        // created with the card sale event.
+        if (string.IsNullOrEmpty(paymentAttempt.AttemptKey))
+        {
+            paymentAttempt.AttemptKey = groupedCardEvent.Key ?? string.Empty;
+            paymentAttempt.PaymentRequestID = cardSaleEvents.First().PaymentRequestID;
+            paymentAttempt.InitiatedAt = cardSaleEvents.First().Inserted;
+            paymentAttempt.PaymentMethod = PaymentMethodTypeEnum.card;
+            paymentAttempt.Currency = cardSaleEvents.First().Currency;
+            paymentAttempt.AttemptedAmount = cardSaleEvents.First().Amount;
+            paymentAttempt.PaymentProcessor = cardSaleEvents.First().PaymentProcessorName;
+        }
+
+        foreach (var cardSaleEvent in cardSaleEvents)
+        {
+            if (cardSaleEvent.IsSuccessfulCardCaptureOrSaleEvent())
+            {
+                paymentAttempt.CaptureAttempts.AddRange(new[]
+                {
+                    new PaymentRequestCaptureAttempt()
+                    {
+                        CapturedAmount = cardSaleEvent.Amount,
+                        CapturedAt = cardSaleEvent.Inserted
+                    }
+                });
+
+                // In case if checkout, we don't get a card authorisation event. Hence, to fill the authorised
+                // amount and authorised at date, we use the card sale event.
+                paymentAttempt.CardAuthorisedAt ??= cardSaleEvent.Inserted;
+
+                paymentAttempt.CardAuthorisedAmount = paymentAttempt.CardAuthorisedAmount == 0
+                    ? cardSaleEvent.Amount
+                    : paymentAttempt.CardAuthorisedAmount;
+                
+                if (string.IsNullOrEmpty(paymentAttempt.TokenisedCardID))
+                {
+                    paymentAttempt.TokenisedCardID = cardSaleEvent.TokenisedCardID?.ToString();
+                }
+
+                break;
+            }
+
+            // Soft decline event means that it has to be captured later.
+            if (!cardSaleEvent.IsSoftDeclineSaleEvent())
+            {
+                paymentAttempt.CaptureAttempts.AddRange(new[]
+                {
+                    new PaymentRequestCaptureAttempt
+                    {
+                        CaptureFailedAt = cardSaleEvent.Inserted,
+                        CaptureFailureError = cardSaleEvent.ErrorMessage
+                    }
+                });
+            }
+            else
+            {
+                paymentAttempt.CardAuthorisedAt ??= cardSaleEvent.Inserted;
+
+                paymentAttempt.CardAuthorisedAmount = paymentAttempt.CardAuthorisedAmount == 0
+                    ? cardSaleEvent.Amount
+                    : paymentAttempt.CardAuthorisedAmount;
+            }
+        }
+    }
+
+    public static void HandleCardVoidEvents(this IGrouping<string?, PaymentRequestEvent> groupedCardEvent,
+        PaymentRequestPaymentAttempt paymentAttempt)
+    {
+        var cardVoidEvents =
+            groupedCardEvent.Where(x => x.EventType == PaymentRequestEventTypesEnum.card_void).ToList();
+
+        if (!cardVoidEvents.Any())
+        {
+            return;
+        }
+
+        var refundAttempts = (from cardVoidEvent in cardVoidEvents
+            where cardVoidEvent.Status == CardPaymentResponseStatus.CARD_VOIDED_SUCCESS_STATUS
+            select new PaymentRequestRefundAttempt
+            {
+                RefundInitiatedAt = cardVoidEvent.Inserted,
+                RefundInitiatedAmount = cardVoidEvent.Amount,
+                RefundSettledAt = cardVoidEvent.Inserted,
+                RefundSettledAmount = cardVoidEvent.Amount,
+            }).ToList();
+
+        paymentAttempt.RefundAttempts = refundAttempts;
+    }
+
+    public static void SetWalletName(this IGrouping<string?, PaymentRequestEvent> groupedCardEvent,
+        PaymentRequestPaymentAttempt paymentAttempt)
+    {
+        if (groupedCardEvent.Any(x => x.WalletName != null))
+        {
+            paymentAttempt.WalletName = groupedCardEvent.First(x => x.WalletName != null).WalletName;
+        }
+    }
+    
+    private static bool IsCardRelatedEvent(this PaymentRequestEvent paymentRequestEvent)
+    {
+        return paymentRequestEvent.EventType == PaymentRequestEventTypesEnum.card_payer_authentication_setup
+                || paymentRequestEvent.EventType == PaymentRequestEventTypesEnum.card_authorization
+                || paymentRequestEvent.EventType == PaymentRequestEventTypesEnum.card_sale
+                || paymentRequestEvent.EventType == PaymentRequestEventTypesEnum.card_capture
+                || paymentRequestEvent.EventType == PaymentRequestEventTypesEnum.card_void;
+    }
+
+    public static List<IGrouping<string?, PaymentRequestEvent>> GetGroupedCardEvents(
+        this IEnumerable<PaymentRequestEvent> paymentRequestEvents)
+    {
+        return paymentRequestEvents
+            .Where(
+                x => !string.IsNullOrEmpty(x.CardAuthorizationResponseID)
+                     && x.IsCardRelatedEvent()).OrderBy(x => x.Inserted)
+            .GroupBy(x => x.CardAuthorizationResponseID).ToList();
+    }
+
+    private static bool IsSuccessfulCardAuthorisationEvent(this PaymentRequestEvent paymentRequestEvent)
+    {
+        return paymentRequestEvent.EventType == PaymentRequestEventTypesEnum.card_authorization &&
+               paymentRequestEvent.Status == CardPaymentResponseStatus.CARD_AUTHORIZED_SUCCESS_STATUS
+               || paymentRequestEvent.Status == CardPaymentResponseStatus.CARD_PAYMENT_SOFT_DECLINE_STATUS
+               || paymentRequestEvent.Status == CardPaymentResponseStatus.CARD_CHECKOUT_AUTHORIZED_STATUS
+               || paymentRequestEvent.Status == CardPaymentResponseStatus.CARD_CHECKOUT_CARDVERFIED_STATUS;
+    }
+
+    private static bool IsSuccessfulCardCaptureOrSaleEvent(this PaymentRequestEvent paymentRequestEvent)
+    {
+        return (paymentRequestEvent.EventType == PaymentRequestEventTypesEnum.card_sale ||
+                paymentRequestEvent.EventType == PaymentRequestEventTypesEnum.card_capture) &&
+               (
+                   paymentRequestEvent.Status == CardPaymentResponseStatus.CARD_AUTHORIZED_SUCCESS_STATUS ||
+                   paymentRequestEvent.Status == CardPaymentResponseStatus.CARD_CHECKOUT_CAPTURED_STATUS ||
+                   paymentRequestEvent.Status == CardPaymentResponseStatus.CARD_CAPTURE_SUCCESS_STATUS
+               );
+    }
+    
+    private static bool IsSoftDeclineSaleEvent(this PaymentRequestEvent paymentRequestEvent)
+    {
+        return paymentRequestEvent.EventType == PaymentRequestEventTypesEnum.card_sale &&
+               paymentRequestEvent.Status == CardPaymentResponseStatus.CARD_PAYMENT_SOFT_DECLINE_STATUS;
+    }
+
+    private static List<PaymentRequestEvent> GetAllCardCaptureEvents(
+        this IGrouping<string?, PaymentRequestEvent> groupedCardEvent)
+    {
+        return groupedCardEvent.Any(x => x.EventType == PaymentRequestEventTypesEnum.card_capture)
+            ? groupedCardEvent
+                .Where(x => x.EventType == PaymentRequestEventTypesEnum.card_capture)
+                .ToList()
+            : new List<PaymentRequestEvent>();
+    }
+
+    private static List<PaymentRequestEvent> GetAllCardSaleEvents(
+        this IGrouping<string?, PaymentRequestEvent> groupedCardEvent)
+    {
+        return groupedCardEvent.Any(x=>x.EventType == PaymentRequestEventTypesEnum.card_sale) ? groupedCardEvent
+            .Where(x => x.EventType == PaymentRequestEventTypesEnum.card_sale)
+            .ToList() : new List<PaymentRequestEvent>();
+    }
+}

--- a/test/MoneyMoov.UnitTests/Models/PaymentRequestEventExtensionsTests.cs
+++ b/test/MoneyMoov.UnitTests/Models/PaymentRequestEventExtensionsTests.cs
@@ -1,0 +1,507 @@
+﻿// -----------------------------------------------------------------------------
+//  Filename: PaymentRequestEventExtensionsTests.cs
+// 
+//  Description: Tests for PaymentRequestEventExtensions.
+// 
+//  Author(s):
+//  Saurav Maiti (saurav@nofrixion.com)
+// 
+//  History:
+//  24 07 2023  Saurav Maiti Created, Harcourt Street, Dublin, Ireland.
+// 
+//  License:
+//  Proprietary NoFrixion.
+// -----------------------------------------------------------------------------
+
+
+using NoFrixion.MoneyMoov;
+using NoFrixion.MoneyMoov.Extensions;
+using NoFrixion.MoneyMoov.Models;
+using Xunit;
+
+namespace MoneyMoov.UnitTests.Models;
+
+public class PaymentRequestEventExtensionsTests
+{
+    [Fact]
+    public void GetGroupedCardEvents_Success()
+    {
+        var cardAuthorizationResponseID = Guid.NewGuid().ToString();
+        var paymentRequestID = Guid.NewGuid();
+        var cardRequestID = Guid.NewGuid().ToString();
+        var amount = 12.12m;
+        var cardEvent1 = new PaymentRequestEvent
+        {
+            ID = Guid.NewGuid(),
+            PaymentRequestID = paymentRequestID,
+            Amount = amount,
+            Currency = CurrencyTypeEnum.EUR,
+            Inserted = DateTime.UtcNow,
+            EventType = PaymentRequestEventTypesEnum.card_payer_authentication_setup,
+            Status = "PENDING",
+            PaymentProcessorName = PaymentProcessorsEnum.Checkout,
+            CardAuthorizationResponseID = cardAuthorizationResponseID,
+            CardRequestID = cardRequestID,
+        };
+
+        var cardEvent2 = new PaymentRequestEvent
+        {
+            ID = Guid.NewGuid(),
+            PaymentRequestID = paymentRequestID,
+            Amount = amount,
+            Currency = CurrencyTypeEnum.EUR,
+            Inserted = DateTime.UtcNow,
+            EventType = PaymentRequestEventTypesEnum.card_authorization,
+            Status = "AUTHORIZED",
+            PaymentProcessorName = PaymentProcessorsEnum.Checkout,
+            CardAuthorizationResponseID = cardAuthorizationResponseID,
+            CardRequestID = cardRequestID,
+        };
+
+        var cardEvent3 = new PaymentRequestEvent
+        {
+            ID = Guid.NewGuid(),
+            PaymentRequestID = paymentRequestID,
+            Amount = amount,
+            Currency = CurrencyTypeEnum.EUR,
+            Inserted = DateTime.UtcNow,
+            EventType = PaymentRequestEventTypesEnum.card_capture,
+            Status = "CAPTURED",
+            PaymentProcessorName = PaymentProcessorsEnum.Checkout,
+            CardAuthorizationResponseID = cardAuthorizationResponseID,
+            CardRequestID = cardRequestID,
+        };
+        
+        var cardEvent4 = new PaymentRequestEvent
+        {
+            ID = Guid.NewGuid(),
+            PaymentRequestID = paymentRequestID,
+            Amount = amount,
+            Currency = CurrencyTypeEnum.EUR,
+            Inserted = DateTime.UtcNow,
+            EventType = PaymentRequestEventTypesEnum.card_sale,
+            Status = "CAPTURED",
+            PaymentProcessorName = PaymentProcessorsEnum.Checkout,
+            CardAuthorizationResponseID = cardAuthorizationResponseID,
+            CardRequestID = cardRequestID,
+        };
+        
+        var cardEvent5 = new PaymentRequestEvent
+        {
+            ID = Guid.NewGuid(),
+            PaymentRequestID = paymentRequestID,
+            Amount = amount,
+            Currency = CurrencyTypeEnum.EUR,
+            Inserted = DateTime.UtcNow,
+            EventType = PaymentRequestEventTypesEnum.card_void,
+            Status = "VOIDED",
+            PaymentProcessorName = PaymentProcessorsEnum.Checkout,
+            CardAuthorizationResponseID = cardAuthorizationResponseID,
+            CardRequestID = cardRequestID,
+        };
+
+        List<PaymentRequestEvent> paymentRequestEvents = new List<PaymentRequestEvent>()
+        {
+            cardEvent1, cardEvent2, cardEvent3, cardEvent4, cardEvent5
+        };
+        
+        List<IGrouping<string?, PaymentRequestEvent>> groupedCardEvents = paymentRequestEvents.GetGroupedCardEvents();
+        
+        Assert.Equal(1, groupedCardEvents.Count);
+        Assert.Equal(5, groupedCardEvents.First().Count());
+    }
+
+        [Fact]
+        public void HandleCardAuthorisationEvents_NoCardAuthorizationEvent_NoChangesToPaymentAttempt()
+        {
+            var cardAuthorizationResponseID = Guid.NewGuid().ToString();
+            var paymentRequestID = Guid.NewGuid();
+            var cardRequestID = Guid.NewGuid().ToString();
+            var amount = 12.12m;
+            
+            // Arrange
+            var paymentAttempt = new PaymentRequestPaymentAttempt();
+            var groupedCardEvents = new List<PaymentRequestEvent>
+            {
+                new()
+                {
+                    ID = Guid.NewGuid(),
+                    PaymentRequestID = paymentRequestID,
+                    Amount = amount,
+                    Currency = CurrencyTypeEnum.EUR,
+                    Inserted = DateTime.UtcNow,
+                    EventType = PaymentRequestEventTypesEnum.card_payer_authentication_setup,
+                    Status = "PENDING",
+                    PaymentProcessorName = PaymentProcessorsEnum.Checkout,
+                    CardAuthorizationResponseID = cardAuthorizationResponseID,
+                    CardRequestID = cardRequestID,
+                }
+            }.GroupBy(e => e.CardAuthorizationResponseID);
+
+            // Act
+            groupedCardEvents.Single(x=>x.Key == cardAuthorizationResponseID).HandleCardAuthorisationEvents(paymentAttempt);
+
+            // Assert
+            Assert.Equal(string.Empty, paymentAttempt.AttemptKey);
+            Assert.Equal(Guid.Empty, paymentAttempt.PaymentRequestID);
+            Assert.Null(paymentAttempt.CardAuthorisedAt);
+            Assert.Equal(0, paymentAttempt.CardAuthorisedAmount);
+        }
+
+        [Fact]
+        public void HandleCardAuthorisationEvents_SuccessfulCardAuthorizationEvent_UpdatesPaymentAttempt()
+        {
+            // Arrange
+            var paymentAttempt = new PaymentRequestPaymentAttempt();
+            var cardAuthorizationResponseID = Guid.NewGuid().ToString();
+            var paymentRequestID = Guid.NewGuid();
+            var cardRequestID = Guid.NewGuid().ToString();
+            var amount = 12.12m;
+            var cardEvents = new List<PaymentRequestEvent>
+            {
+                new()
+                {
+                    ID = Guid.NewGuid(),
+                    PaymentRequestID = paymentRequestID,
+                    Amount = amount,
+                    Currency = CurrencyTypeEnum.EUR,
+                    Inserted = DateTime.UtcNow,
+                    EventType = PaymentRequestEventTypesEnum.card_payer_authentication_setup,
+                    Status = "PENDING",
+                    PaymentProcessorName = PaymentProcessorsEnum.Checkout,
+                    CardAuthorizationResponseID = cardAuthorizationResponseID,
+                    CardRequestID = cardRequestID,
+                },
+
+                new()
+                {
+                    ID = Guid.NewGuid(),
+                    PaymentRequestID = paymentRequestID,
+                    Amount = amount,
+                    Currency = CurrencyTypeEnum.EUR,
+                    Inserted = DateTime.UtcNow,
+                    EventType = PaymentRequestEventTypesEnum.card_authorization,
+                    Status = "AUTHORIZED",
+                    PaymentProcessorName = PaymentProcessorsEnum.Checkout,
+                    CardAuthorizationResponseID = cardAuthorizationResponseID,
+                    CardRequestID = cardRequestID,
+                }
+            };
+            var groupedCardEvents = cardEvents.GroupBy(e => e.CardAuthorizationResponseID);
+
+            // Act
+            groupedCardEvents.Single(x=>x.Key == cardAuthorizationResponseID).HandleCardAuthorisationEvents(paymentAttempt);
+
+            // Assert
+            Assert.NotNull(paymentAttempt.CardAuthorisedAt);
+            Assert.Equal(amount, paymentAttempt.CardAuthorisedAmount);
+        }
+        
+        [Fact]
+        public void HandleCardAuthorisationEvents_NoCardCaptureEvent_NoChangesToPaymentAttempt()
+        {
+            var cardAuthorizationResponseID = Guid.NewGuid().ToString();
+            var paymentRequestID = Guid.NewGuid();
+            var cardRequestID = Guid.NewGuid().ToString();
+            var amount = 12.12m;
+            
+            // Arrange
+            var paymentAttempt = new PaymentRequestPaymentAttempt();
+            var groupedCardEvents = new List<PaymentRequestEvent>
+            {
+                new()
+                {
+                    ID = Guid.NewGuid(),
+                    PaymentRequestID = paymentRequestID,
+                    Amount = amount,
+                    Currency = CurrencyTypeEnum.EUR,
+                    Inserted = DateTime.UtcNow,
+                    EventType = PaymentRequestEventTypesEnum.card_payer_authentication_setup,
+                    Status = "PENDING",
+                    PaymentProcessorName = PaymentProcessorsEnum.Checkout,
+                    CardAuthorizationResponseID = cardAuthorizationResponseID,
+                    CardRequestID = cardRequestID,
+                }
+            }.GroupBy(e => e.CardAuthorizationResponseID);
+
+            // Act
+            groupedCardEvents.Single(x=>x.Key == cardAuthorizationResponseID).HandleCardCaptureEvents(paymentAttempt);
+
+            // Assert
+            Assert.Equal(string.Empty, paymentAttempt.AttemptKey);
+            Assert.Equal(Guid.Empty, paymentAttempt.PaymentRequestID);
+            Assert.Equal(0, paymentAttempt.CaptureAttempts.Count);
+        }
+
+        [Fact]
+        public void HandleCardAuthorisationEvents_SuccessfulCardCaptureEvent_UpdatesPaymentAttempt()
+        {
+            // Arrange
+            var paymentAttempt = new PaymentRequestPaymentAttempt();
+            var cardAuthorizationResponseID = Guid.NewGuid().ToString();
+            var paymentRequestID = Guid.NewGuid();
+            var cardRequestID = Guid.NewGuid().ToString();
+            var amount = 12.12m;
+            var cardEvents = new List<PaymentRequestEvent>
+            {
+                new()
+                {
+                    ID = Guid.NewGuid(),
+                    PaymentRequestID = paymentRequestID,
+                    Amount = amount,
+                    Currency = CurrencyTypeEnum.EUR,
+                    Inserted = DateTime.UtcNow,
+                    EventType = PaymentRequestEventTypesEnum.card_payer_authentication_setup,
+                    Status = "PENDING",
+                    PaymentProcessorName = PaymentProcessorsEnum.Checkout,
+                    CardAuthorizationResponseID = cardAuthorizationResponseID,
+                    CardRequestID = cardRequestID,
+                },
+
+                new()
+                {
+                    ID = Guid.NewGuid(),
+                    PaymentRequestID = paymentRequestID,
+                    Amount = amount,
+                    Currency = CurrencyTypeEnum.EUR,
+                    Inserted = DateTime.UtcNow,
+                    EventType = PaymentRequestEventTypesEnum.card_authorization,
+                    Status = "AUTHORIZED",
+                    PaymentProcessorName = PaymentProcessorsEnum.Checkout,
+                    CardAuthorizationResponseID = cardAuthorizationResponseID,
+                    CardRequestID = cardRequestID,
+                },
+                new()
+                {
+                    ID = Guid.NewGuid(),
+                    PaymentRequestID = paymentRequestID,
+                    Amount = amount,
+                    Currency = CurrencyTypeEnum.EUR,
+                    Inserted = DateTime.UtcNow,
+                    EventType = PaymentRequestEventTypesEnum.card_capture,
+                    Status = "CAPTURED",
+                    PaymentProcessorName = PaymentProcessorsEnum.Checkout,
+                    CardAuthorizationResponseID = cardAuthorizationResponseID,
+                    CardRequestID = cardRequestID,
+                }
+            };
+            var groupedCardEvents = cardEvents.GroupBy(e => e.CardAuthorizationResponseID);
+
+            // Act
+            groupedCardEvents.Single(x=>x.Key == cardAuthorizationResponseID).HandleCardCaptureEvents(paymentAttempt);
+
+            // Assert
+            Assert.Equal(1, paymentAttempt.CaptureAttempts.Count);
+        }
+        
+        [Fact]
+        public void HandleCardAuthorisationEvents_NoCardSaleEvent_NoChangesToPaymentAttempt()
+        {
+            var cardAuthorizationResponseID = Guid.NewGuid().ToString();
+            var paymentRequestID = Guid.NewGuid();
+            var cardRequestID = Guid.NewGuid().ToString();
+            var amount = 12.12m;
+            
+            // Arrange
+            var paymentAttempt = new PaymentRequestPaymentAttempt();
+            var groupedCardEvents = new List<PaymentRequestEvent>
+            {
+                new()
+                {
+                    ID = Guid.NewGuid(),
+                    PaymentRequestID = paymentRequestID,
+                    Amount = amount,
+                    Currency = CurrencyTypeEnum.EUR,
+                    Inserted = DateTime.UtcNow,
+                    EventType = PaymentRequestEventTypesEnum.card_payer_authentication_setup,
+                    Status = "PENDING",
+                    PaymentProcessorName = PaymentProcessorsEnum.Checkout,
+                    CardAuthorizationResponseID = cardAuthorizationResponseID,
+                    CardRequestID = cardRequestID,
+                }
+            }.GroupBy(e => e.CardAuthorizationResponseID);
+
+            // Act
+            groupedCardEvents.Single(x=>x.Key == cardAuthorizationResponseID).HandleCardSaleEvents(paymentAttempt);
+
+            // Assert
+            Assert.Equal(string.Empty, paymentAttempt.AttemptKey);
+            Assert.Equal(Guid.Empty, paymentAttempt.PaymentRequestID);
+            Assert.Equal(0, paymentAttempt.CaptureAttempts.Count);
+        }
+
+        [Fact]
+        public void HandleCardAuthorisationEvents_SuccessfulCardSaleEvent_UpdatesPaymentAttempt()
+        {
+            // Arrange
+            var paymentAttempt = new PaymentRequestPaymentAttempt();
+            var cardAuthorizationResponseID = Guid.NewGuid().ToString();
+            var paymentRequestID = Guid.NewGuid();
+            var cardRequestID = Guid.NewGuid().ToString();
+            var amount = 12.12m;
+            var cardEvents = new List<PaymentRequestEvent>
+            {
+                new()
+                {
+                    ID = Guid.NewGuid(),
+                    PaymentRequestID = paymentRequestID,
+                    Amount = amount,
+                    Currency = CurrencyTypeEnum.EUR,
+                    Inserted = DateTime.UtcNow,
+                    EventType = PaymentRequestEventTypesEnum.card_payer_authentication_setup,
+                    Status = "PENDING",
+                    PaymentProcessorName = PaymentProcessorsEnum.Checkout,
+                    CardAuthorizationResponseID = cardAuthorizationResponseID,
+                    CardRequestID = cardRequestID,
+                },
+                new()
+                {
+                    ID = Guid.NewGuid(),
+                    PaymentRequestID = paymentRequestID,
+                    Amount = amount,
+                    Currency = CurrencyTypeEnum.EUR,
+                    Inserted = DateTime.UtcNow,
+                    EventType = PaymentRequestEventTypesEnum.card_sale,
+                    Status = "CAPTURED",
+                    PaymentProcessorName = PaymentProcessorsEnum.Checkout,
+                    CardAuthorizationResponseID = cardAuthorizationResponseID,
+                    CardRequestID = cardRequestID,
+                }
+            };
+            var groupedCardEvents = cardEvents.GroupBy(e => e.CardAuthorizationResponseID);
+
+            // Act
+            groupedCardEvents.Single(x=>x.Key == cardAuthorizationResponseID).HandleCardSaleEvents(paymentAttempt);
+
+            // Assert
+            Assert.Equal(1, paymentAttempt.CaptureAttempts.Count);
+            Assert.True(paymentAttempt.CardAuthorisedAmount > 0);
+            Assert.NotNull(paymentAttempt.CardAuthorisedAt);
+        }
+        
+        [Fact]
+        public void HandleCardAuthorisationEvents_NoCardVoidEvent_NoChangesToPaymentAttempt()
+        {
+            var cardAuthorizationResponseID = Guid.NewGuid().ToString();
+            var paymentRequestID = Guid.NewGuid();
+            var cardRequestID = Guid.NewGuid().ToString();
+            var amount = 12.12m;
+            
+            // Arrange
+            var paymentAttempt = new PaymentRequestPaymentAttempt();
+            var groupedCardEvents = new List<PaymentRequestEvent>
+            {
+                new()
+                {
+                    ID = Guid.NewGuid(),
+                    PaymentRequestID = paymentRequestID,
+                    Amount = amount,
+                    Currency = CurrencyTypeEnum.EUR,
+                    Inserted = DateTime.UtcNow,
+                    EventType = PaymentRequestEventTypesEnum.card_payer_authentication_setup,
+                    Status = "PENDING",
+                    PaymentProcessorName = PaymentProcessorsEnum.Checkout,
+                    CardAuthorizationResponseID = cardAuthorizationResponseID,
+                    CardRequestID = cardRequestID,
+                }
+            }.GroupBy(e => e.CardAuthorizationResponseID);
+
+            // Act
+            groupedCardEvents.Single(x=>x.Key == cardAuthorizationResponseID).HandleCardVoidEvents(paymentAttempt);
+
+            // Assert
+            Assert.Equal(string.Empty, paymentAttempt.AttemptKey);
+            Assert.Equal(Guid.Empty, paymentAttempt.PaymentRequestID);
+            Assert.Equal(0, paymentAttempt.RefundAttempts.Count);
+        }
+
+        [Fact]
+        public void HandleCardAuthorisationEvents_SuccessfulCardVoidEvent_UpdatesPaymentAttempt()
+        {
+            // Arrange
+            var paymentAttempt = new PaymentRequestPaymentAttempt();
+            var cardAuthorizationResponseID = Guid.NewGuid().ToString();
+            var paymentRequestID = Guid.NewGuid();
+            var cardRequestID = Guid.NewGuid().ToString();
+            var amount = 12.12m;
+            var cardEvents = new List<PaymentRequestEvent>
+            {
+                new ()
+                {
+                    ID = Guid.NewGuid(),
+                    PaymentRequestID = paymentRequestID,
+                    Amount = amount,
+                    Currency = CurrencyTypeEnum.EUR,
+                    Inserted = DateTime.UtcNow,
+                    EventType = PaymentRequestEventTypesEnum.card_payer_authentication_setup,
+                    Status = "PENDING",
+                    PaymentProcessorName = PaymentProcessorsEnum.Checkout,
+                    CardAuthorizationResponseID = cardAuthorizationResponseID,
+                    CardRequestID = cardRequestID,
+                },
+
+                new()
+                {
+                    ID = Guid.NewGuid(),
+                    PaymentRequestID = paymentRequestID,
+                    Amount = amount,
+                    Currency = CurrencyTypeEnum.EUR,
+                    Inserted = DateTime.UtcNow,
+                    EventType = PaymentRequestEventTypesEnum.card_authorization,
+                    Status = "AUTHORIZED",
+                    PaymentProcessorName = PaymentProcessorsEnum.Checkout,
+                    CardAuthorizationResponseID = cardAuthorizationResponseID,
+                    CardRequestID = cardRequestID,
+                },
+
+                new ()
+                {
+                    ID = Guid.NewGuid(),
+                    PaymentRequestID = paymentRequestID,
+                    Amount = amount,
+                    Currency = CurrencyTypeEnum.EUR,
+                    Inserted = DateTime.UtcNow,
+                    EventType = PaymentRequestEventTypesEnum.card_capture,
+                    Status = "CAPTURED",
+                    PaymentProcessorName = PaymentProcessorsEnum.Checkout,
+                    CardAuthorizationResponseID = cardAuthorizationResponseID,
+                    CardRequestID = cardRequestID,
+                },
+
+                new ()
+                {
+                    ID = Guid.NewGuid(),
+                    PaymentRequestID = paymentRequestID,
+                    Amount = amount,
+                    Currency = CurrencyTypeEnum.EUR,
+                    Inserted = DateTime.UtcNow,
+                    EventType = PaymentRequestEventTypesEnum.card_sale,
+                    Status = "CAPTURED",
+                    PaymentProcessorName = PaymentProcessorsEnum.Checkout,
+                    CardAuthorizationResponseID = cardAuthorizationResponseID,
+                    CardRequestID = cardRequestID,
+                },
+
+                new ()
+                {
+                    ID = Guid.NewGuid(),
+                    PaymentRequestID = paymentRequestID,
+                    Amount = amount,
+                    Currency = CurrencyTypeEnum.EUR,
+                    Inserted = DateTime.UtcNow,
+                    EventType = PaymentRequestEventTypesEnum.card_void,
+                    Status = "VOIDED",
+                    PaymentProcessorName = PaymentProcessorsEnum.Checkout,
+                    CardAuthorizationResponseID = cardAuthorizationResponseID,
+                    CardRequestID = cardRequestID,
+                }
+            };
+            var groupedCardEvents = cardEvents.GroupBy(e => e.CardAuthorizationResponseID);
+
+            // Act
+            groupedCardEvents.Single(x=>x.Key == cardAuthorizationResponseID).HandleCardVoidEvents(paymentAttempt);
+
+            // Assert
+            Assert.Equal(1, paymentAttempt.RefundAttempts.Count);
+        }
+}

--- a/test/MoneyMoov.UnitTests/Models/PaymentRequestExtensionTests.cs
+++ b/test/MoneyMoov.UnitTests/Models/PaymentRequestExtensionTests.cs
@@ -272,8 +272,8 @@ namespace MoneyMoov.UnitTests.Models
             Assert.NotEmpty(cardAttempts);
             Assert.Single(cardAttempts);
             Assert.Equal(PaymentResultEnum.FullyPaid, cardAttempts.First().Status);
-            Assert.Equal(amount, cardAttempts.First().SettledAmount);
-            Assert.Equal(amount, cardAttempts.First().AuthorisedAmount);
+            Assert.Equal(amount, cardAttempts.First().CaptureAttempts.Sum(x=>x.CapturedAmount));
+            Assert.Equal(amount, cardAttempts.First().CardAuthorisedAmount);
             Assert.Equal(CurrencyTypeEnum.EUR, cardAttempts.First().Currency);
             Assert.Equal(PaymentProcessorsEnum.Checkout, cardAttempts.First().PaymentProcessor);
             Assert.Equal(PaymentMethodTypeEnum.card, cardAttempts.First().PaymentMethod);
@@ -338,8 +338,8 @@ namespace MoneyMoov.UnitTests.Models
             Assert.NotEmpty(cardAttempts);
             Assert.Single(cardAttempts);
             Assert.Equal(PaymentResultEnum.FullyPaid, cardAttempts.First().Status);
-            Assert.Equal(amount, cardAttempts.First().SettledAmount);
-            Assert.Equal(amount, cardAttempts.First().AuthorisedAmount);
+            Assert.Equal(amount, cardAttempts.First().CaptureAttempts.Sum(x=>x.CapturedAmount));
+            Assert.Equal(amount, cardAttempts.First().CardAuthorisedAmount);
             Assert.Equal(CurrencyTypeEnum.EUR, cardAttempts.First().Currency);
             Assert.Equal(PaymentProcessorsEnum.Checkout, cardAttempts.First().PaymentProcessor);
             Assert.Equal(PaymentMethodTypeEnum.card, cardAttempts.First().PaymentMethod);

--- a/test/MoneyMoov.UnitTests/Models/PaymentRequestResultTests.cs
+++ b/test/MoneyMoov.UnitTests/Models/PaymentRequestResultTests.cs
@@ -49,7 +49,8 @@ public class PaymentRequestResultTests
             Currency = entity.Currency,
             Inserted = DateTime.UtcNow,
             EventType = PaymentRequestEventTypesEnum.card_sale,
-            Status = CardPaymentResponseStatus.CARD_AUTHORIZED_SUCCESS_STATUS
+            Status = CardPaymentResponseStatus.CARD_AUTHORIZED_SUCCESS_STATUS,
+            CardAuthorizationResponseID = Guid.NewGuid().ToString()
         };
 
         entity.Events = new List<PaymentRequestEvent> { successEvent };
@@ -91,7 +92,8 @@ public class PaymentRequestResultTests
             Currency = entity.Currency,
             Inserted = DateTime.UtcNow,
             EventType = PaymentRequestEventTypesEnum.card_sale,
-            Status = CardPaymentResponseStatus.CARD_AUTHORIZED_SUCCESS_STATUS
+            Status = CardPaymentResponseStatus.CARD_AUTHORIZED_SUCCESS_STATUS,
+            CardAuthorizationResponseID = "dummy"
         };
 
         entity.Events = new List<PaymentRequestEvent> { successEvent };
@@ -119,7 +121,8 @@ public class PaymentRequestResultTests
             Currency = entity.Currency,
             Inserted = DateTime.UtcNow,
             EventType = PaymentRequestEventTypesEnum.card_sale,
-            Status = CardPaymentResponseStatus.CARD_AUTHORIZED_SUCCESS_STATUS
+            Status = CardPaymentResponseStatus.CARD_AUTHORIZED_SUCCESS_STATUS,
+            CardAuthorizationResponseID = Guid.NewGuid().ToString()
         };
 
         entity.Events = new List<PaymentRequestEvent> { successEvent };
@@ -282,7 +285,8 @@ public class PaymentRequestResultTests
             Currency = entity.Currency,
             Inserted = DateTime.UtcNow,
             EventType = PaymentRequestEventTypesEnum.card_sale,
-            Status = CardPaymentResponseStatus.CARD_PAYMENT_SOFT_DECLINE_STATUS
+            Status = CardPaymentResponseStatus.CARD_PAYMENT_SOFT_DECLINE_STATUS,
+            CardAuthorizationResponseID = Guid.NewGuid().ToString()
         };
 
         entity.Events = new List<PaymentRequestEvent> { successEvent };
@@ -303,7 +307,9 @@ public class PaymentRequestResultTests
     public void Card_Authorise_And_Capture_Fully_Paid_Payment_Result()
     {
         var entity = GetTestPaymentRequest();
+        entity.CardAuthorizeOnly = true;
 
+        var cardAuthorizationResponseID = Guid.NewGuid().ToString();
         var authoriseEvent = new PaymentRequestEvent
         {
             ID = Guid.NewGuid(),
@@ -312,7 +318,8 @@ public class PaymentRequestResultTests
             Currency = entity.Currency,
             Inserted = DateTime.UtcNow,
             EventType = PaymentRequestEventTypesEnum.card_authorization,
-            Status = CardPaymentResponseStatus.CARD_AUTHORIZED_SUCCESS_STATUS
+            Status = CardPaymentResponseStatus.CARD_AUTHORIZED_SUCCESS_STATUS,
+            CardAuthorizationResponseID = cardAuthorizationResponseID
         };
 
         var captureEvent = new PaymentRequestEvent
@@ -323,7 +330,8 @@ public class PaymentRequestResultTests
             Currency = entity.Currency,
             Inserted = DateTime.UtcNow,
             EventType = PaymentRequestEventTypesEnum.card_capture,
-            Status = CardPaymentResponseStatus.CARD_CAPTURE_SUCCESS_STATUS
+            Status = CardPaymentResponseStatus.CARD_CAPTURE_SUCCESS_STATUS,
+            CardAuthorizationResponseID = cardAuthorizationResponseID
         };
 
         entity.Events = new List<PaymentRequestEvent> { authoriseEvent, captureEvent };


### PR DESCRIPTION
1. Update Payment request result logic to use Card payment attempts.
2. Added CardAuthorisedAmount to PaymentAttempts to differentiate it from Pisp AuthorisedAmount as they are completely different.
3. SettledAmount is solely for pisp and CaptureAttempts collection is for cards. This differentiation is necessary because it can get confusing as they mean completely different things.
4. Wrote new test cases and updated existing ones. Integration tests are already written for this.