### PR TITLE
Add two model properties to improve handling of pay by bank failures

### DIFF
--- a/src/NoFrixion.MoneyMoov/Models/PaymentRequests/PaymentRequest.cs
+++ b/src/NoFrixion.MoneyMoov/Models/PaymentRequests/PaymentRequest.cs
@@ -92,6 +92,15 @@ public class PaymentRequest : IPaymentRequest, IWebhookPayload
     public string? CallbackUrl { get; set; }
 
     /// <summary>
+    /// Optional callback URL for payment failures that can occur when the payer is 
+    /// redirected away from the payment page. Typically the payer is only sent away
+    /// from the payment page for pay by bank attempts. If this URL is not set the 
+    /// payer will be redirected back to the original URL the payment attempt was initiated
+    /// from.
+    /// </summary>
+    public string? FailureCallbackUrl { get; set; }
+
+    /// <summary>
     /// If a payment event results in the payment request being classified as fully paid this
     /// success webhook URL will be invoked. The URL will be invoked as a GET request, i.e.
     /// there will be no request body. Two query parameters will be added to the URL. The 

--- a/src/NoFrixion.MoneyMoov/Models/PaymentRequests/PaymentRequestCreate.cs
+++ b/src/NoFrixion.MoneyMoov/Models/PaymentRequests/PaymentRequestCreate.cs
@@ -170,6 +170,15 @@ public class PaymentRequestCreate : IValidatableObject, IPaymentRequest
     public string? CallbackUrl { get; set; }
 
     /// <summary>
+    /// Optional callback URL for payment failures that can occur when the payer is 
+    /// redirected away from the payment page. Typically the payer is only sent away
+    /// from the payment page for pay by bank attempts. If this URL is not set the 
+    /// payer will be redirected back to the original URL the payment attempt was initiated
+    /// from.
+    /// </summary>
+    public string? FailureCallbackUrl { get; set; }
+
+    /// <summary>
     /// If a payment event results in the payment request being classified as fully paid this
     /// success webhook URL will be invoked. The URL will be invoked as a GET request, i.e.
     /// there will be no request body. Two query parameters will be added to the URL. The 
@@ -357,6 +366,7 @@ public class PaymentRequestCreate : IValidatableObject, IPaymentRequest
         dict.Add(nameof(Description), Description ?? string.Empty);
         dict.Add(nameof(BaseOriginUrl), BaseOriginUrl!);
         dict.Add(nameof(CallbackUrl), CallbackUrl!);
+        dict.Add(nameof(FailureCallbackUrl), FailureCallbackUrl ?? string.Empty);
         dict.Add(nameof(CardAuthorizeOnly), CardAuthorizeOnly.ToString());
         dict.Add(nameof(CardCreateToken), CardCreateToken.ToString());
         dict.Add(nameof(CardTransmitRawDetails), CardTransmitRawDetails.ToString());

--- a/src/NoFrixion.MoneyMoov/Models/PaymentRequests/PaymentRequestEvent.cs
+++ b/src/NoFrixion.MoneyMoov/Models/PaymentRequests/PaymentRequestEvent.cs
@@ -132,6 +132,12 @@ public class PaymentRequestEvent
     public Guid? TokenisedCardID { get; set; }
 
     /// <summary>
+    /// Optional field that can be set by payment methods, such as pay by bank, that may want to redirect
+    /// back to the URL that initiated the attempt in the case of a failure condition.
+    /// </summary>
+    public string? OriginUrl { get; set; }
+
+    /// <summary>
     /// Gets the amount to display with the correct number of decimal places based on the currency type. 
     /// </summary>
     /// <returns>The decimal amount to display for the payment request's currency.</returns>

--- a/src/NoFrixion.MoneyMoov/Models/PaymentRequests/PaymentRequestUpdate.cs
+++ b/src/NoFrixion.MoneyMoov/Models/PaymentRequests/PaymentRequestUpdate.cs
@@ -149,6 +149,15 @@ public class PaymentRequestUpdate
     public string? CallbackUrl { get; set; }
 
     /// <summary>
+    /// Optional callback URL for payment failures that can occur when the payer is 
+    /// redirected away from the payment page. Typically the payer is only sent away
+    /// from the payment page for pay by bank attempts. If this URL is not set the 
+    /// payer will be redirected back to the original URL the payment attempt was initiated
+    /// from.
+    /// </summary>
+    public string? FailureCallbackUrl { get; set; }
+
+    /// <summary>
     /// For card payments the default behaviour is to authorise and capture the payment at the same
     /// time. If a merchant needs to authorise and then capture at a later point this property needs
     /// to be set to true.
@@ -250,6 +259,7 @@ public class PaymentRequestUpdate
         if (ShippingEmail != null)  dict.Add(nameof(ShippingEmail), ShippingEmail);
         if (BaseOriginUrl != null) dict.Add(nameof(BaseOriginUrl), BaseOriginUrl);
         if (CallbackUrl != null) dict.Add(nameof(CallbackUrl), CallbackUrl);
+        if (FailureCallbackUrl != null) dict.Add(nameof(FailureCallbackUrl), FailureCallbackUrl);
         if (CardAuthorizeOnly != null) dict.Add(nameof(CardAuthorizeOnly), CardAuthorizeOnly.Value.ToString());
         if (CardCreateToken != null) dict.Add(nameof(CardCreateToken), CardCreateToken.Value.ToString());
         if (IgnoreAddressVerification != null) dict.Add(nameof(IgnoreAddressVerification), IgnoreAddressVerification.Value.ToString());


### PR DESCRIPTION
> Add FailureCallbackUrl to payment request event models. 
> Add OriginUrl to payment request event model.