### PR TITLE
Added extension methods 

### DIFF
--- a/src/NoFrixion.MoneyMoov/Enums/PaymentRequestEventTypesEnum.cs
+++ b/src/NoFrixion.MoneyMoov/Enums/PaymentRequestEventTypesEnum.cs
@@ -117,4 +117,9 @@ public enum PaymentRequestEventTypesEnum
     /// A card payment was initiated. A webhook is sent out when the status of the payment changes. 
     /// </summary>
     card_webhook = 17,
+    
+    /// <summary>
+    /// A card payment was refunded.
+    /// </summary>
+    card_refund = 18,
 }

--- a/src/NoFrixion.MoneyMoov/Extensions/PaymentRequestEventExtensions.cs
+++ b/src/NoFrixion.MoneyMoov/Extensions/PaymentRequestEventExtensions.cs
@@ -308,7 +308,8 @@ public static class PaymentRequestEventExtensions
                 || paymentRequestEvent.EventType == PaymentRequestEventTypesEnum.card_sale
                 || paymentRequestEvent.EventType == PaymentRequestEventTypesEnum.card_capture
                 || paymentRequestEvent.EventType == PaymentRequestEventTypesEnum.card_void
-                || paymentRequestEvent.EventType == PaymentRequestEventTypesEnum.card_webhook;
+                || paymentRequestEvent.EventType == PaymentRequestEventTypesEnum.card_webhook
+                || paymentRequestEvent.EventType == PaymentRequestEventTypesEnum.card_refund;
     }
 
     public static List<IGrouping<string?, PaymentRequestEvent>> GetGroupedCardEvents(

--- a/src/NoFrixion.MoneyMoov/Extensions/PaymentRequestEventExtensions.cs
+++ b/src/NoFrixion.MoneyMoov/Extensions/PaymentRequestEventExtensions.cs
@@ -194,14 +194,42 @@ public static class PaymentRequestEventExtensions
         }
 
         var refundAttempts = (from cardVoidEvent in cardVoidEvents
-                              where cardVoidEvent.Status == CardPaymentResponseStatus.CARD_VOIDED_SUCCESS_STATUS
+                              where cardVoidEvent.Status == CardPaymentResponseStatus.CARD_VOIDED_SUCCESS_STATUS ||
+                                    cardVoidEvent.Status == CardPaymentResponseStatus.CARD_REFUNDED_SUCCESS_STATUS
                               select new PaymentRequestRefundAttempt
                               {
                                   RefundInitiatedAt = cardVoidEvent.Inserted,
                                   RefundInitiatedAmount = cardVoidEvent.Amount,
                                   RefundSettledAt = cardVoidEvent.Inserted,
                                   RefundSettledAmount = cardVoidEvent.Amount,
+                                  IsCardVoid = true
                               }).ToList();
+
+        paymentAttempt.RefundAttempts = refundAttempts;
+    }
+    
+    public static void HandleCardRefundEvents(this IGrouping<string?, PaymentRequestEvent> groupedCardEvent,
+        PaymentRequestPaymentAttempt paymentAttempt)
+    {
+        var cardRefundEvents =
+            groupedCardEvent.Where(x => x.EventType == PaymentRequestEventTypesEnum.card_refund).ToList();
+
+        if (!cardRefundEvents.Any())
+        {
+            return;
+        }
+
+        var refundAttempts = (from cardRefundEvent in cardRefundEvents
+            where cardRefundEvent.Status == CardPaymentResponseStatus.CARD_CHECKOUT_REFUNDED_SUCCESS_STATUS ||
+                  cardRefundEvent.Status == CardPaymentResponseStatus.CARD_REFUNDED_SUCCESS_STATUS
+            select new PaymentRequestRefundAttempt
+            {
+                RefundInitiatedAt = cardRefundEvent.Inserted,
+                RefundInitiatedAmount = cardRefundEvent.Amount,
+                RefundSettledAt = cardRefundEvent.Inserted,
+                RefundSettledAmount = cardRefundEvent.Amount,
+                IsCardVoid = false
+            }).ToList();
 
         paymentAttempt.RefundAttempts = refundAttempts;
     }

--- a/src/NoFrixion.MoneyMoov/Extensions/PaymentRequestExtensions.cs
+++ b/src/NoFrixion.MoneyMoov/Extensions/PaymentRequestExtensions.cs
@@ -97,6 +97,8 @@ public static class PaymentRequestExtensions
 
             // If there is a card void event, then the payment attempt was refunded.
             attempt.HandleCardVoidEvents(paymentAttempt);
+            
+            attempt.HandleCardRefundEvents(paymentAttempt);
 
             attempt.SetWalletName(paymentAttempt);
 

--- a/src/NoFrixion.MoneyMoov/Extensions/PaymentRequestPaymentAttemptExtensions.cs
+++ b/src/NoFrixion.MoneyMoov/Extensions/PaymentRequestPaymentAttemptExtensions.cs
@@ -44,4 +44,27 @@ public static class PaymentRequestPaymentAttemptExtensions
             _ => PaymentResultEnum.None
         };
     }
+
+    public static bool IsCardPaymentVoided(this PaymentRequestPaymentAttempt attempt)
+    {
+        return (attempt.CardAuthorisedAmount -
+                attempt.CaptureAttempts.Sum(y => y.CapturedAmount) -
+                attempt.RefundAttempts.Where(p => p.IsCardVoid)
+                    .Sum(z => z.RefundSettledAmount)) == 0;
+    }
+
+    public static decimal GetAmountAvailableToRefund(this PaymentRequestPaymentAttempt attempt)
+    {
+        return attempt.CaptureAttempts.Sum(x => x.CapturedAmount) -
+                                       attempt.RefundAttempts.Where(x => x.IsCardVoid == false)
+                                           .Sum(y => y.RefundSettledAmount);
+    }
+    
+    public static decimal GetAmountAvailableToVoid(this PaymentRequestPaymentAttempt attempt)
+    {
+        return attempt.CardAuthorisedAmount -
+               attempt.CaptureAttempts.Sum(x => x.CapturedAmount) -
+               attempt.RefundAttempts.Where(x => x.IsCardVoid)
+                   .Sum(y => y.RefundSettledAmount);
+    }
 }

--- a/src/NoFrixion.MoneyMoov/Models/PaymentRequests/CardPaymentResponseStatus.cs
+++ b/src/NoFrixion.MoneyMoov/Models/PaymentRequests/CardPaymentResponseStatus.cs
@@ -63,4 +63,14 @@ public static class CardPaymentResponseStatus
     /// The successful status result returned for a checkout authorisation card payment request.
     /// </summary>
     public const string CARD_CHECKOUT_CARDVERFIED_STATUS = "CardVerified";
+    
+    /// <summary>
+    /// The successful status result returned for a cybersource refund card payment request.
+    /// </summary>
+    public const string CARD_REFUNDED_SUCCESS_STATUS = "PENDING";
+    
+    /// <summary>
+    /// The successful status result returned for a refund card payment request.
+    /// </summary>
+    public const string CARD_CHECKOUT_REFUNDED_SUCCESS_STATUS = "REFUNDED";
 }

--- a/src/NoFrixion.MoneyMoov/Models/PaymentRequests/PaymentRequestPaymentAttempt.cs
+++ b/src/NoFrixion.MoneyMoov/Models/PaymentRequests/PaymentRequestPaymentAttempt.cs
@@ -145,6 +145,8 @@ public class PaymentRequestRefundAttempt
     public decimal RefundSettledAmount { get; set; }
 
     public decimal RefundCancelledAmount { get; set; }
+    
+    public bool IsCardVoid { get; set; }
 }
 
 /// <summary>


### PR DESCRIPTION
Added extension methods for PaymentRequestPaymentAttempt to calculate amount available to refund and void. Introduced a flag in refund attempts to differentiate between card refund and void.

Also, added a new event type called card_refund to differentiate between card voids and refunds. 