### PR TITLE
Additional payment processor and enhancements to REST response

### DIFF
--- a/src/NoFrixion.MoneyMoov/Enums/PaymentProcessorsEnum.cs
+++ b/src/NoFrixion.MoneyMoov/Enums/PaymentProcessorsEnum.cs
@@ -73,8 +73,13 @@ public enum PaymentProcessorsEnum
     BitcoinTestnet,
 
     /// <summary>
-    /// Agency banking supplier.
+    /// Banking Circle standard accounts.
     /// </summary>
-    BankingCircle
+    BankingCircle,
+
+    /// <summary>
+    /// Banking Circle agency banking accounts.
+    /// </summary>
+    BankingCircleAgency
 }
 

--- a/src/NoFrixion.MoneyMoov/NoFrixionProblem.cs
+++ b/src/NoFrixion.MoneyMoov/NoFrixionProblem.cs
@@ -204,6 +204,15 @@ public class NoFrixionProblem
     [JsonPropertyName("errors")]
     public Dictionary<string, string[]> Errors { get; set; } = new Dictionary<string, string[]>();
 
+    /// <summary>
+    /// This field can be used when a remote error response cannot be deserialised and it's useful to
+    /// take copy of the raw error. Mainly useful for REST API responses from server that return an 
+    /// unknown, on non-JSON, format.
+    /// </summary>
+    [JsonIgnore]
+    [IgnoreDataMember]
+    public string RawError { get; set; } = string.Empty;
+
     [JsonIgnore]
     [IgnoreDataMember]
     public bool IsEmpty => _isEmpty;

--- a/src/NoFrixion.MoneyMoov/RestClient/RestApiResponse.cs
+++ b/src/NoFrixion.MoneyMoov/RestClient/RestApiResponse.cs
@@ -20,31 +20,31 @@ using System.Net.Http.Headers;
 
 namespace NoFrixion.MoneyMoov;
 
-/// <summary>
-/// Provides a non-generic contract for the ApiResponse wrapper.
-/// </summary>
-public interface IRestApiResponse
-{
-    /// <summary>
-    /// Gets or sets the status code (HTTP status code)
-    /// </summary>
-    /// <value>The status code.</value>
-    HttpStatusCode StatusCode { get; }
+///// <summary>
+///// Provides a non-generic contract for the ApiResponse wrapper.
+///// </summary>
+//public interface IRestApiResponse
+//{
+//    /// <summary>
+//    /// Gets or sets the status code (HTTP status code)
+//    /// </summary>
+//    /// <value>The status code.</value>
+//    HttpStatusCode StatusCode { get; }
 
-    Option<Uri> RequestUri { get; }
+//    Option<Uri> RequestUri { get; }
 
-    /// <summary>
-    /// Gets or sets the HTTP headers
-    /// </summary>
-    /// <value>HTTP headers</value>
-    Option<HttpResponseHeaders> Headers { get; }
+//    /// <summary>
+//    /// Gets or sets the HTTP headers
+//    /// </summary>
+//    /// <value>HTTP headers</value>
+//    Option<HttpResponseHeaders> Headers { get; }
 
-    /// <summary>
-    /// Will be set for non 2xx responses and holds any available information about why the 
-    /// request failed.
-    /// </summary>
-    NoFrixionProblem Problem { get; }
-}
+//    /// <summary>
+//    /// Will be set for non 2xx responses and holds any available information about why the 
+//    /// request failed.
+//    /// </summary>
+//    NoFrixionProblem Problem { get; }
+//}
 
 /// <summary>
 /// Base class for REST API Response.
@@ -95,7 +95,7 @@ public class RestApiResponse
 /// <summary>
 /// Generic REST API Response.
 /// </summary>
-public class RestApiResponse<T> : RestApiResponse, IRestApiResponse
+public class RestApiResponse<T> : RestApiResponse //, IRestApiResponse
 {
     /// <summary>
     /// Gets or sets the data (parsed HTTP body)


### PR DESCRIPTION
Add two payment processors to differentiate between BC standard and agency banking.

Add raw error property to NoFrixionProblem for cases where the error contents don't match the expected model.