### PR TITLE
[MOOV-2204]: Added missing payout metric statuses

### DIFF
--- a/src/NoFrixion.MoneyMoov/Models/PaymentMetrics/MetricBase.cs
+++ b/src/NoFrixion.MoneyMoov/Models/PaymentMetrics/MetricBase.cs
@@ -26,7 +26,7 @@ public enum MetricsEnum
     All = 0,
     
     /// <summary>
-    /// For use with payment requests and payouts.
+    /// For use with payment requests.
     /// </summary>
     Unpaid = 1,
     
@@ -49,6 +49,16 @@ public enum MetricsEnum
     /// For use with PendingApproval payouts.
     /// </summary>
     PendingApproval = 5,
+    
+    /// <summary>
+    /// For use with InProgress payouts.
+    /// </summary>
+    InProgress = 6,
+    
+    /// <summary>
+    /// For use with Failed payouts.
+    /// </summary>
+    Failed = 7
 }
 
 /// <summary>

--- a/src/NoFrixion.MoneyMoov/Models/Payouts/PayoutMetrics.cs
+++ b/src/NoFrixion.MoneyMoov/Models/Payouts/PayoutMetrics.cs
@@ -22,9 +22,10 @@ public class PayoutMetrics : MetricBase
         TotalAmountsByCurrency = new Dictionary<string, Dictionary<string, decimal>>()
         {
             { MetricsEnum.All.ToString(), new Dictionary<string, decimal>() },
-            { MetricsEnum.Paid.ToString(), new Dictionary<string, decimal>() },
-            { MetricsEnum.Unpaid.ToString(), new Dictionary<string, decimal>() },
+            { MetricsEnum.InProgress.ToString(), new Dictionary<string, decimal>() },
             { MetricsEnum.PendingApproval.ToString(), new Dictionary<string, decimal>() },
+            { MetricsEnum.Failed.ToString(), new Dictionary<string, decimal>() },
+            { MetricsEnum.Paid.ToString(), new Dictionary<string, decimal>() },
         };
     }
 
@@ -34,14 +35,19 @@ public class PayoutMetrics : MetricBase
     public decimal All { get; set; }
     
     /// <summary>
-    /// Payouts with status Unknown, Rejected, Failed, Pending, PendingInput, Queued or QueuedUpstream.
+    /// Payouts with Pending, Queued or QueuedUpstream status.
     /// </summary>
-    public decimal Unpaid { get; set; }
+    public decimal InProgress { get; set; }
     
     /// <summary>
     /// Payouts with PendingApproval status.
     /// </summary>
     public decimal PendingApproval { get; set; }
+
+    /// <summary>
+    /// Payouts with Failed, Rejected, PendingInput or Unknown status. 
+    /// </summary>
+    public decimal Failed { get; set; }
     
     /// <summary>
     /// Payouts with Processed status.


### PR DESCRIPTION
Added InProgress (Pending, Queued or QueuedUpstream status) and Failed (Failed, Rejected, PendingInput or Unknown) statuses to the payout metrics endpoint.