### PR TITLE
Adjust the string substitution logic for payreq email notifications

### DIFF
--- a/src/NoFrixion.MoneyMoov/Extensions/StringExtensions.cs
+++ b/src/NoFrixion.MoneyMoov/Extensions/StringExtensions.cs
@@ -156,4 +156,20 @@ public static class StringExtensions
             return false;
         }
     }
+
+    /// <summary>
+    /// Takes a format string, e.g. "{Property1} and {Property2}", and attempts to find matching
+    /// items in teh dictionary to replace the placeholder keys with.
+    /// </summary>
+    /// <param name="template">The template string with the format keys.</param>
+    /// <param name="record">A dictionary with values that can be sued to substitute into the string template.</param>
+    /// <returns>The template string with substitutions done.</returns>
+    public static string Substitute(this string template, IDictionary<string, object> record)
+    {
+        return Regex.Replace(template, @"\{(.+?)\}", match =>
+        {
+            string columnName = match.Groups[1].Value;
+            return record.ContainsKey(columnName) ? record[columnName]?.ToString()?.Trim() ?? string.Empty : "{" + columnName + "}";
+        });
+    }
 }

--- a/src/NoFrixion.MoneyMoov/Mapping/CsvMapper.cs
+++ b/src/NoFrixion.MoneyMoov/Mapping/CsvMapper.cs
@@ -15,7 +15,7 @@
 
 using CsvHelper;
 using System.Globalization;
-using System.Text.RegularExpressions;
+using NoFrixion.MoneyMoov.Extensions;
 
 namespace NoFrixion.MoneyMoov;
 
@@ -27,11 +27,17 @@ public class CsvMapResult<T> where T : new()
 
     public NoFrixionProblem Problem { get; set; }
 
+    /// <summary>
+    /// The CSV row mapped to header, value pairs.
+    /// </summary>
+    public IDictionary<string, object> CsvMappedRow { get; set; }
+
     public CsvMapResult()
     {
         CsvRow = string.Empty;
         Model = new T();
         Problem = NoFrixionProblem.Empty;
+        CsvMappedRow = new Dictionary<string, object>();
     }
 }
 
@@ -64,6 +70,8 @@ public static class CsvMapper
                 }
                 else
                 {
+                    result.CsvMappedRow = (IDictionary<string, object>)record;
+
                     try
                     {
                         foreach (var property in typeof(T).GetProperties())
@@ -71,7 +79,7 @@ public static class CsvMapper
                             if (mapping.ContainsKey(property.Name))
                             {
                                 string template = mapping[property.Name];
-                                string formattedValue = SubstitutePlaceholdersWithValues(template, (IDictionary<string, object>)record);
+                                string formattedValue = template.Substitute((IDictionary<string, object>)record);
 
                                 if (property.PropertyType == typeof(Guid))
                                 {
@@ -112,15 +120,6 @@ public static class CsvMapper
                 yield return result;
             }
         }
-    }
-
-    private static string SubstitutePlaceholdersWithValues(string template, IDictionary<string, object> record)
-    {
-        return Regex.Replace(template, @"\{(.+?)\}", match =>
-        {
-            string columnName = match.Groups[1].Value;
-            return record[columnName]?.ToString()?.Trim() ?? string.Empty;
-        });
     }
 }
 

--- a/src/NoFrixion.MoneyMoov/Models/PaymentRequests/PaymentRequestEmailNotification.cs
+++ b/src/NoFrixion.MoneyMoov/Models/PaymentRequests/PaymentRequestEmailNotification.cs
@@ -87,31 +87,12 @@ public class PaymentRequestEmailNotification
             return formatString;
         }
 
-        //string substitutedString = formatString;
-
         IDictionary<string, object> payReqMapping = typeof(PaymentRequest)
             .GetProperties()
             .ToDictionary(
                 prop => prop.Name,
                 prop => prop.GetValue(paymentRequest, null) ?? string.Empty
             );
-
-        // First stage is to substitute payment request fields.
-        //substitutedString = CsvMapper.SubstitutePlaceholdersWithValues(substitutedString, payReqMapping);
-
-        //foreach (var property in typeof(PaymentRequest).GetProperties())
-        //{
-        //    string matchString = "{" + property.Name + "}";
-
-        //    if (substitutedString.Contains(matchString))
-        //    {
-        //        string propValue = property.GetValue(paymentRequest, null)?.ToString() ?? string.Empty;
-        //        substitutedString = substitutedString.Replace(matchString, propValue, StringComparison.InvariantCultureIgnoreCase);
-        //    }
-        //}
-
-        // Second stage is to substitute csv mapped results.
-        //substitutedString = substitutedString.Substitute(csvMappedRow);
 
         return formatString.Substitute(payReqMapping).Substitute(csvMappedRow);
     }

--- a/test/MoneyMoov.UnitTests/Models/PaymentRequestEmailNotificationTests.cs
+++ b/test/MoneyMoov.UnitTests/Models/PaymentRequestEmailNotificationTests.cs
@@ -71,7 +71,7 @@ public class PaymentRequestEmailNotificationTests : MoneyMoovUnitTestBase<Paymen
             }
         };
 
-        var substitutedNotification = emailNotification.SubstituteVariables(paymentRequest);
+        var substitutedNotification = emailNotification.SubstituteVariables(paymentRequest, new Dictionary<string, object>());
 
         Assert.NotNull(substitutedNotification);
         Assert.Equal("some-template", substitutedNotification.TemplateName);
@@ -84,5 +84,74 @@ public class PaymentRequestEmailNotificationTests : MoneyMoovUnitTestBase<Paymen
         Assert.Equal("Super Title", substitutedNotification.TemplateVariables["Title"]);
         Assert.Equal("Super Title, Blah blah blah.", substitutedNotification.TemplateVariables["Description"]);
         Assert.Equal("https://api-sandbox.nofrixion.com/pay/v2/xxx", substitutedNotification.TemplateVariables["HostedPayCheckoutUrl"]);
+    }
+
+    /// <summary>
+    /// Tests that the template string is formatted correctly when the values are from both a payment request
+    /// and an additional dictionary.
+    /// </summary>
+    [Fact]
+    public void Substitute_With_PaymentRequest_And_Dictionary_Test()
+    {
+        Logger.LogDebug($"--> {TypeExtensions.GetCaller()}.");
+
+        var emailNotification = new PaymentRequestEmailNotification
+        {
+            TemplateName = "some-template",
+            ToEmailAddress = "{CustomerEmailAddress}",
+            FromEmailAddress = "support@nofrixion.com",
+            Subject = "{Title}",
+            TemplateVariables = new Dictionary<string, string>
+            {
+                { "CustomerName", "{CustomerName}"},
+                { "OrderID", "{OrderID}" },
+                { "DisplayAmount", "{FormattedAmount}" },
+                { "Title", "{Title}"},
+                { "Description", "{Title}, {Description}"},
+                { "HostedPayCheckoutUrl", "{HostedPayCheckoutUrl}" },
+                { "CompanyName", "{CompanyName}" }
+            }
+        };
+
+        var paymentRequest = new PaymentRequest
+        {
+            ID = Guid.NewGuid(),
+            Currency = CurrencyTypeEnum.EUR,
+            PaymentMethodTypes = PaymentMethodTypeEnum.card | PaymentMethodTypeEnum.pisp,
+            CustomerEmailAddress = "jane.doe@nofrixion.com",
+            Amount = 10001.99M,
+            Title = "Super Title",
+            Description = "Blah blah blah.",
+            HostedPayCheckoutUrl = "https://api-sandbox.nofrixion.com/pay/v2/xxx",
+            OrderID = "1234",
+            Addresses = new List<PaymentRequestAddress>
+            {
+                new PaymentRequestAddress
+                {
+                    FirstName = "Jane",
+                    LastName = "Doe"
+                }
+            }
+        };
+
+        var csvMapping = new Dictionary<string, object>
+        {
+            { "CompanyName", "Some Company" }
+        };
+
+        var substitutedNotification = emailNotification.SubstituteVariables(paymentRequest, csvMapping);
+
+        Assert.NotNull(substitutedNotification);
+        Assert.Equal("some-template", substitutedNotification.TemplateName);
+        Assert.Equal("jane.doe@nofrixion.com", substitutedNotification.ToEmailAddress);
+        Assert.Equal("support@nofrixion.com", substitutedNotification.FromEmailAddress);
+        Assert.Equal("Super Title", substitutedNotification.Subject);
+        Assert.Equal("€10,001.99", substitutedNotification.TemplateVariables["DisplayAmount"]);
+        Assert.Equal("1234", substitutedNotification.TemplateVariables["OrderID"]);
+        Assert.Equal("Jane Doe", substitutedNotification.TemplateVariables["CustomerName"]);
+        Assert.Equal("Super Title", substitutedNotification.TemplateVariables["Title"]);
+        Assert.Equal("Super Title, Blah blah blah.", substitutedNotification.TemplateVariables["Description"]);
+        Assert.Equal("https://api-sandbox.nofrixion.com/pay/v2/xxx", substitutedNotification.TemplateVariables["HostedPayCheckoutUrl"]);
+        Assert.Equal("Some Company", substitutedNotification.TemplateVariables["CompanyName"]);
     }
 }


### PR DESCRIPTION
A need arose to use both the payment request AND csv result variables in teh email template.