### PR TITLE
[MOOV-2291]: Added source account balance field to payout model

### DIFF
--- a/src/NoFrixion.MoneyMoov/Models/Payouts/Payout.cs
+++ b/src/NoFrixion.MoneyMoov/Models/Payouts/Payout.cs
@@ -188,6 +188,11 @@ public class Payout : IValidatableObject, IWebhookPayload
     /// The sort code of the account the payout is being made from.
     /// </summary>
     public string? SourceAccountSortcode { get; set; } = string.Empty;
+
+    /// <summary>
+    /// The available balance of the account the payout is being made from.
+    /// </summary>
+    public decimal? SourceAccountAvailableBalance { get; set; }
     
     [Obsolete("Please use Destination.")]
     [System.Text.Json.Serialization.JsonIgnore]


### PR DESCRIPTION
Added source account balance field to payout model to render it on the Identity Server's single-payout approval screen.