### PR TITLE
Add Bitcoin fee fields to payout models.

### DIFF
--- a/src/NoFrixion.MoneyMoov/Models/Payouts/Payout.cs
+++ b/src/NoFrixion.MoneyMoov/Models/Payouts/Payout.cs
@@ -229,6 +229,17 @@ public class Payout : IValidatableObject, IWebhookPayload
     public DateTimeOffset? ScheduleDate { get; set; }
 
     /// <summary>
+    /// For Bitcoin payouts, when this flag is set the network fee will be deducted from the send amount.
+    /// THis is particularly useful for sweeps where it can be difficult to calculate the exact fee required.
+    /// </summary>
+    public bool BitcoinSubtractFeeFromAmount { get; set; }
+
+    /// <summary>
+    /// The Bitcoin fee rate to apply in Satoshis per virtual byte.
+    /// </summary>
+    public int BitcoinFeeSatsPerVbyte { get; set; }
+
+    /// <summary>
     /// The number of authorisers required for this payout. Is determined by business settings
     /// on the source account and/or merchant.
     /// </summary>
@@ -240,9 +251,14 @@ public class Payout : IValidatableObject, IWebhookPayload
     public int AuthorisersCompletedCount { get; set; }
     
     /// <summary>
-    /// True if the user who loaded the payout has authorised it.
+    /// True if the payout can be authorised by the user who loaded it.
     /// </summary>
-    public bool HasCurrentUserAuthorised { get; set; }
+    public bool CanAuthorise { get; set; }
+
+    /// <summary>
+    /// True if the payout can be updated by the user who loaded it.
+    /// </summary>
+    public bool CanUpdate { get; set; }
 
     public NoFrixionProblem Validate()
     {

--- a/src/NoFrixion.MoneyMoov/Models/Payouts/PayoutCreate.cs
+++ b/src/NoFrixion.MoneyMoov/Models/Payouts/PayoutCreate.cs
@@ -139,7 +139,18 @@ public class PayoutCreate
     /// The date the payout should be submitted.
     /// </summary>
     public DateTimeOffset? ScheduleDate { get; set; }
-    
+
+    /// <summary>
+    /// For Bitcoin payouts, when this flag is set the network fee will be deducted from the send amount.
+    /// THis is particularly useful for sweeps where it can be difficult to calculate the exact fee required.
+    /// </summary>
+    public bool BitcoinSubtractFeeFromAmount { get; set; }
+
+    /// <summary>
+    /// The Bitcoin fee rate to apply in Satoshis per virtual byte.
+    /// </summary>
+    public int BitcoinFeeSatsPerVbyte { get; set; }
+
     /// <summary>
     /// Places all the payout's properties into a dictionary.
     /// </summary>

--- a/src/NoFrixion.MoneyMoov/Models/Payouts/PayoutUpdate.cs
+++ b/src/NoFrixion.MoneyMoov/Models/Payouts/PayoutUpdate.cs
@@ -123,7 +123,18 @@ public class PayoutUpdate
     /// The date the payout should be submitted.
     /// </summary>
     public DateTimeOffset? ScheduleDate { get; set; }
-    
+
+    /// <summary>
+    /// For Bitcoin payouts, when this flag is set the network fee will be deducted from the send amount.
+    /// THis is particularly useful for sweeps where it can be difficult to calculate the exact fee required.
+    /// </summary>
+    public bool? BitcoinSubtractFeeFromAmount { get; set; }
+
+    /// <summary>
+    /// The Bitcoin fee rate to apply in Satoshis per virtual byte.
+    /// </summary>
+    public int? BitcoinFeeSatsPerVbyte { get; set; }
+
     /// <summary>
     /// Places all the payout's properties into a dictionary.
     /// </summary>


### PR DESCRIPTION
 Add can update and can authorise flags to give user an indication of available actions.