### PR TITLE
Adjusted payout update model to allow updating of Bitcoin address.

### DIFF
--- a/src/NoFrixion.MoneyMoov/Models/Payouts/PayoutUpdate.cs
+++ b/src/NoFrixion.MoneyMoov/Models/Payouts/PayoutUpdate.cs
@@ -97,6 +97,18 @@ public class PayoutUpdate
         set => Destination = value;
     }
 
+    [Obsolete("Please use Destination.")]
+    public string? DestinationBitcoinAddress
+    {
+        get => Destination?.Identifier?.BitcoinAddress;
+        set
+        {
+            Destination ??= new Counterparty();
+            Destination.Identifier ??= new AccountIdentifier();
+            Destination.Identifier.BitcoinAddress = value;
+        }
+    }
+
     public Counterparty? Destination { get; set; }
 
     /// <summary>


### PR DESCRIPTION
We will need to change or improve our field mapper update approach soon as it cannot deal with nested objects.