### PR TITLE
Added beneficiary details to event

### DIFF
--- a/src/NoFrixion.MoneyMoov/Enums/BeneficiaryEventTypeEnum.cs
+++ b/src/NoFrixion.MoneyMoov/Enums/BeneficiaryEventTypeEnum.cs
@@ -18,7 +18,28 @@ namespace NoFrixion.MoneyMoov.Enums;
 
 public enum BeneficiaryEventTypeEnum
 {
-    Authorise,
-    Update,
-    Disable
+    /// <summary>
+    /// Something went wrong and the event type is unknown.
+    /// </summary>
+    Unknown = 0,
+    
+    /// <summary>
+    /// A beneficiary was created.
+    /// </summary>
+    Create = 1,
+    
+    /// <summary>
+    /// A beneficiary was authorised by an approver.
+    /// </summary>
+    Authorise = 2,
+    
+    /// <summary>
+    /// A beneficiary was updated.
+    /// </summary>
+    Update = 3,
+    
+    /// <summary>
+    /// A beneficiary was disabled.
+    /// </summary>
+    Disable = 4,
 }

--- a/src/NoFrixion.MoneyMoov/Models/Beneficiary/BeneficiaryEvent.cs
+++ b/src/NoFrixion.MoneyMoov/Models/Beneficiary/BeneficiaryEvent.cs
@@ -35,6 +35,20 @@ public class BeneficiaryEvent
     public string ErrorReason { get; set; }
 
     public string ErrorMessage { get; set; }
+    
+    public CurrencyTypeEnum Currency { get; set; }
+    
+    public Guid? AccountID { get; set; }
+    
+    public string AccountName { get; set; }
+    
+    public string IBAN { get; set; }
+    
+    public string AccountNumber { get; set; }
+    
+    public string SortCode { get; set; }
+    
+    public string BitcoinAddress { get; set; }
 
     public DateTimeOffset Inserted { get; set; }
 

--- a/src/NoFrixion.MoneyMoov/Models/Beneficiary/BeneficiaryEvent.cs
+++ b/src/NoFrixion.MoneyMoov/Models/Beneficiary/BeneficiaryEvent.cs
@@ -36,6 +36,8 @@ public class BeneficiaryEvent
 
     public string ErrorMessage { get; set; }
     
+    public string BeneficiaryName { get; set; }
+    
     public CurrencyTypeEnum Currency { get; set; }
     
     public Guid? AccountID { get; set; }


### PR DESCRIPTION
In the beneficiary authorisation process, if a beneficiary has been updated, it has to be re-authorised. 

There is a separate design for Authorisation page for updated beneficiary in identity server. In order to implement that, we need to know which properties were updated to add the "Updated" tag beside it. 

Hence, this PR adds all the beneficiary details in the events so a history of update is available which can be used in the identity server.

![Screenshot 2023-11-22 130151](https://github.com/nofrixion/moneymoov-dotnet/assets/103389834/82270a46-4b57-472c-8b0a-a124d451e776)

