### PR TITLE
Changed AccountID type from Guid to string.

### DIFF
--- a/src/NoFrixion.MoneyMoov/Models/Beneficiary/BeneficiaryUpdate.cs
+++ b/src/NoFrixion.MoneyMoov/Models/Beneficiary/BeneficiaryUpdate.cs
@@ -22,7 +22,7 @@ public class BeneficiaryUpdate
     /// <summary>
     /// ID of the account to which the beneficiary belongs.
     /// </summary>
-    public Guid? AccountID { get; set; }
+    public string? AccountID { get; set; }
 
     /// <summary>
     /// The descriptive name for the beneficiary.


### PR DESCRIPTION
Changed the type of AccountID in BeneficiaryUpdate model from Guid to string. This is done so the user can switch a beneficiary from Merchant level to account level. Let's say a beneficiary was created with AccountID which is account level. Now, the AccountID needs to be removed so the beneficiary is available at the merchant level. If an empty string is passed then the AccountID will be removed if present. And if it is null then the user does not intend to do anything to the AccountID. If it is set to a different AccountID then it will get updated.