### PR TITLE
Remove Duplicate `Subtotal` Property in `PayrunInvoice` Class

### DIFF
--- a/src/NoFrixion.MoneyMoov/Models/Payruns/PayrunInvoice.cs
+++ b/src/NoFrixion.MoneyMoov/Models/Payruns/PayrunInvoice.cs
@@ -44,8 +44,6 @@ public class PayrunInvoice
     public string? DestinationSortCode { get; set; }
 
     public CurrencyTypeEnum Currency { get; set; }
-    
-    public decimal? Subtotal { get; set; }
 
     public decimal? Discounts { get; set; }
 


### PR DESCRIPTION
This PR addresses am issue where a duplicated 'Subtotal' property in the `PayrunInvoice` class was causing a 500 error in the API. The error was identified during API calls involving the `PayrunInvoice` data structure.

# Changes
- **Removed Duplicated 'Subtotal' Property**: Identified and removed the redundant 'Subtotal' property from the `PayrunInvoice` class. This duplication was leading to serialization issues and resulting in a 500 error during API responses.