### PR TITLE
Updated PayoutCreate, PayoutUpdate to use BeneficiaryID instead of BeneficiaryIdentifierID

### DIFF
--- a/src/NoFrixion.MoneyMoov/Models/Payouts/Payout.cs
+++ b/src/NoFrixion.MoneyMoov/Models/Payouts/Payout.cs
@@ -312,14 +312,20 @@ public class Payout : IValidatableObject, IWebhookPayload
     public List<string>? AuthorisedBy { get; set; }
 
     /// <summary>
-    /// If the payout destination is a beneficairy this will be the ID of it's identifier.
+    /// If the payout destination is a beneficiary this will be the ID of it's identifier.
     /// </summary>
     public Guid? BeneficiaryIdentifierID { get; set; }
 
     /// <summary>
     /// If the payout is using a beneficiary for the destination this is the name of the it.
     /// </summary>
+    [Obsolete("Please use Beneficiary.")]
     public string? BeneficiaryName { get; set; }
+    
+    /// <summary>
+    /// Optional beneficiary associated with the payout.
+    /// </summary>
+    public Beneficiary? Beneficiary { get; set; }
 
     /// <summary>
     /// The activity associated with the payout.

--- a/src/NoFrixion.MoneyMoov/Models/Payouts/PayoutCreate.cs
+++ b/src/NoFrixion.MoneyMoov/Models/Payouts/PayoutCreate.cs
@@ -150,11 +150,17 @@ public class PayoutCreate
     /// The Bitcoin fee rate to apply in Satoshis per virtual byte.
     /// </summary>
     public int BitcoinFeeSatsPerVbyte { get; set; }
-
+    
     /// <summary>
     /// Optional. The ID of the beneficiary identifier to use for the payout destination.
     /// </summary>
+    [Obsolete("Please use BeneficiaryID to set the beneficiary.")]
     public Guid? BeneficiaryIdentifierID { get; set; }
+
+    /// <summary>
+    /// Optional. The ID of the beneficiary to use for the payout destination.
+    /// </summary>
+    public Guid? BeneficiaryID { get; set; }
 
     /// <summary>
     /// Places all the payout's properties into a dictionary.
@@ -174,7 +180,7 @@ public class PayoutCreate
             { nameof(TheirReference), TheirReference ?? string.Empty},
             { nameof(InvoiceID), InvoiceID ?? string.Empty },
             { nameof(AllowIncomplete), AllowIncomplete.ToString() },
-            { nameof(BeneficiaryIdentifierID), BeneficiaryIdentifierID?.ToString() ?? string.Empty }
+            { nameof(BeneficiaryID), BeneficiaryID?.ToString() ?? string.Empty }
         };
 
         if (Destination != null)

--- a/src/NoFrixion.MoneyMoov/Models/Payouts/PayoutUpdate.cs
+++ b/src/NoFrixion.MoneyMoov/Models/Payouts/PayoutUpdate.cs
@@ -146,11 +146,17 @@ public class PayoutUpdate
     /// The Bitcoin fee rate to apply in Satoshis per virtual byte.
     /// </summary>
     public int? BitcoinFeeSatsPerVbyte { get; set; }
-
+    
     /// <summary>
     /// Optional. The ID of the beneficiary identifier to use for the payout destination.
     /// </summary>
+    [Obsolete("Please use BeneficiaryID to update the beneficiary.")]
     public Guid? BeneficiaryIdentifierID { get; set; }
+
+    /// <summary>
+    /// Optional. The ID of the beneficiary to use for the payout destination.
+    /// </summary>
+    public Guid? BeneficiaryID { get; set; }
 
     /// <summary>
     /// Places all the payout's properties into a dictionary.


### PR DESCRIPTION
- Updated PayoutCreate, PayoutUpdate to use BeneficiaryID instead of BeneficiaryIdentifierID.
- Added Beneficiary in the Payout model.