### PR TITLE
Added AccountIdentifierCreate and CounterpartyCreate model. 

### DIFF
--- a/src/NoFrixion.MoneyMoov/Mapping/AccountIdentifierMappers.cs
+++ b/src/NoFrixion.MoneyMoov/Mapping/AccountIdentifierMappers.cs
@@ -1,0 +1,46 @@
+// -----------------------------------------------------------------------------
+//  Filename: AccountIdentifierMapper.cs
+// 
+//  Description: Mapping extensions for AccountIdentifier model
+//  Author(s):
+//  saurav@nofrixion.com (saurav@nofrixion.com)
+// 
+//  History:
+//  16 04 2024  Saurav Maiti   Created, Harcourt street, Dublin, Ireland.
+// 
+//  License:
+//  MIT.
+// -----------------------------------------------------------------------------
+
+using NoFrixion.MoneyMoov.Models;
+
+namespace NoFrixion.MoneyMoov;
+
+public static class AccountIdentifierMapper
+{
+    public static AccountIdentifier ToAccountIdentifier(this AccountIdentifierCreate accountIdentifierCreate, CurrencyTypeEnum currency)
+    {
+        return new AccountIdentifier
+        {
+            AccountNumber = accountIdentifierCreate.AccountNumber,
+            IBAN = accountIdentifierCreate.IBAN,
+            BIC = accountIdentifierCreate.BIC,
+            SortCode = accountIdentifierCreate.SortCode,
+            BitcoinAddress = accountIdentifierCreate.BitcoinAddress,
+            Currency = accountIdentifierCreate.Currency ?? currency
+        };
+    }
+    
+    public static AccountIdentifierCreate ToAccountIdentifierCreate(this AccountIdentifier accountIdentifier)
+    {
+        return new AccountIdentifierCreate
+        {
+            AccountNumber = accountIdentifier.AccountNumber,
+            IBAN = accountIdentifier.IBAN,
+            BIC = accountIdentifier.BIC,
+            SortCode = accountIdentifier.SortCode,
+            BitcoinAddress = accountIdentifier.BitcoinAddress,
+            Currency = accountIdentifier.Currency
+        };
+    }
+}

--- a/src/NoFrixion.MoneyMoov/Mapping/CounterpartyMappers.cs
+++ b/src/NoFrixion.MoneyMoov/Mapping/CounterpartyMappers.cs
@@ -1,0 +1,44 @@
+// -----------------------------------------------------------------------------
+//  Filename: CounterpartyMapper.cs
+// 
+//  Description: Mapping extensions for Counterparty model
+//  Author(s):
+//  saurav@nofrixion.com (saurav@nofrixion.com)
+// 
+//  History:
+//  16 04 2024  Saurav Maiti   Created, Harcourt street, Dublin, Ireland.
+// 
+//  License:
+//  MIT.
+// -----------------------------------------------------------------------------
+
+using NoFrixion.MoneyMoov.Models;
+
+namespace NoFrixion.MoneyMoov;
+
+public static class CounterpartyMapper
+{
+    public static Counterparty ToCounterparty(this CounterpartyCreate counterpartyCreate, CurrencyTypeEnum currency)
+    {
+        return new Counterparty
+        {
+            AccountID = counterpartyCreate.AccountID,
+            Name = counterpartyCreate.Name,
+            EmailAddress = counterpartyCreate.EmailAddress,
+            PhoneNumber = counterpartyCreate.PhoneNumber,
+            Identifier = counterpartyCreate.Identifier?.ToAccountIdentifier(currency)
+        };
+    }
+    
+    public static CounterpartyCreate ToCounterpartyCreate(this Counterparty counterparty)
+    {
+        return new CounterpartyCreate
+        {
+            AccountID = counterparty.AccountID,
+            Name = counterparty.Name,
+            EmailAddress = counterparty.EmailAddress,
+            PhoneNumber = counterparty.PhoneNumber,
+            Identifier = counterparty.Identifier?.ToAccountIdentifierCreate()
+        };
+    }
+}

--- a/src/NoFrixion.MoneyMoov/Models/Account/AccountIdentifier.cs
+++ b/src/NoFrixion.MoneyMoov/Models/Account/AccountIdentifier.cs
@@ -13,11 +13,13 @@
 //  MIT.
 // -----------------------------------------------------------------------------
 
+using System.ComponentModel.DataAnnotations;
+
 namespace NoFrixion.MoneyMoov.Models;
 
 #nullable disable
 
-public class AccountIdentifier
+public class AccountIdentifier: IValidatableObject
 {
     /// <summary>
     /// The type of the account identifier.
@@ -27,7 +29,7 @@ public class AccountIdentifier
     {
         get
         {
-            if(Currency == CurrencyTypeEnum.GBP.ToString())
+            if(Currency == CurrencyTypeEnum.GBP)
             {
                 // UK Faster Payments can support both SCAN and IBAN identifiers. Default to SCAN.
                 if (!string.IsNullOrEmpty(SortCode) && !string.IsNullOrEmpty(AccountNumber))
@@ -63,7 +65,7 @@ public class AccountIdentifier
     /// <summary>
     /// The currency for the account.
     /// </summary>
-    public string Currency { get; set; }
+    public CurrencyTypeEnum? Currency { get; set; }
 
     /// <summary>
     /// The Bank Identifier Code for an IBAN.
@@ -180,15 +182,20 @@ public class AccountIdentifier
     /// </summary>
     public string DisplaySummary =>   
         Type == AccountIdentifierType.IBAN ? IBAN :
-        Type == AccountIdentifierType.SCAN ? SortCode + " / " + AccountNumber :
+        Type == AccountIdentifierType.SCAN ? DisplayScanSummary :
         Type == AccountIdentifierType.BTC ? BitcoinAddress :
         "No identifier.";
+
+    public string DisplayScanSummary =>
+        !string.IsNullOrEmpty(SortCode) && !string.IsNullOrEmpty(AccountNumber) && SortCode.Length == 6
+            ? $"{SortCode[..2]}-{SortCode.Substring(2, 2)}-{SortCode.Substring(4, 2)} {AccountNumber}"
+            : "No identifier.";
 
     public virtual Dictionary<string, string> ToDictionary(string keyPrefix)
     {
         return new Dictionary<string, string>
         {
-            { keyPrefix + nameof(Currency), Currency ?? string.Empty},
+            { keyPrefix + nameof(Currency), Currency.ToString()},
             { keyPrefix + nameof(BIC), BIC ?? string.Empty},
             { keyPrefix + nameof(IBAN), IBAN ?? string.Empty},
             { keyPrefix + nameof(SortCode), SortCode ?? string.Empty},
@@ -200,7 +207,7 @@ public class AccountIdentifier
     public string GetApprovalHash()
     {
         string input =
-            (!string.IsNullOrEmpty(Currency) ? Currency.ToString() : string.Empty) +
+            Currency +
             (!string.IsNullOrEmpty(BIC) ? BIC : string.Empty) +
             (!string.IsNullOrEmpty(IBAN) ? IBAN : string.Empty) +
             (!string.IsNullOrEmpty(SortCode) ? SortCode : string.Empty) +
@@ -212,5 +219,57 @@ public class AccountIdentifier
     public override string ToString()
     {
         return $"Type: {Type}, Currency: {Currency}, BIC: {BIC}, IBAN: {IBAN}, SortCode: {SortCode}, AccountNumber: {AccountNumber}, Bitcoin Address: {BitcoinAddress}, Summary: {Summary}";
+    }
+
+    public NoFrixionProblem Validate()
+    {
+        var validationResults = new List<ValidationResult>();
+        var validationContext = new ValidationContext(this, serviceProvider: null, items: null);
+        var isValid = Validator.TryValidateObject(this, validationContext, validationResults, true);
+        
+        if (!isValid)
+        {
+            return new NoFrixionProblem($"The {nameof(AccountIdentifier)} had one or more validation errors.", validationResults);
+        }
+        
+        return NoFrixionProblem.Empty;
+    }
+
+    public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
+    {
+        switch (Currency)
+        {
+            case CurrencyTypeEnum.GBP:
+            {
+                if (string.IsNullOrEmpty(SortCode) || string.IsNullOrEmpty(AccountNumber))
+                {
+                    yield return new ValidationResult("Sort code and account number are required for GBP account identifier.", new[] { nameof(SortCode), nameof(AccountNumber) });
+                }
+
+                break;
+            }
+            case CurrencyTypeEnum.EUR:
+            {
+                if (string.IsNullOrEmpty(IBAN))
+                {
+                    yield return new ValidationResult("IBAN is required for EUR account identifier.", new[] { nameof(IBAN) });
+                }
+
+                break;
+            }
+            case CurrencyTypeEnum.BTC:
+            {
+                if (string.IsNullOrEmpty(BitcoinAddress))
+                {
+                    yield return new ValidationResult("Bitcoin address is required for BTC account identifier.", new[] { nameof(BitcoinAddress) });
+                }
+
+                break;
+            }
+            case CurrencyTypeEnum.None:
+            default:
+                yield return new ValidationResult("Currency is required.", new[] { nameof(Currency) });
+                break;
+        }
     }
 }

--- a/src/NoFrixion.MoneyMoov/Models/Account/AccountIdentifierCreate.cs
+++ b/src/NoFrixion.MoneyMoov/Models/Account/AccountIdentifierCreate.cs
@@ -18,46 +18,6 @@ namespace NoFrixion.MoneyMoov.Models;
 
 public class AccountIdentifierCreate
 {
-    /// <summary>
-    /// The type of the account identifier.
-    /// </summary>
-    [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
-    public AccountIdentifierType Type
-    {
-        get
-        {
-            if(Currency == CurrencyTypeEnum.GBP)
-            {
-                // UK Faster Payments can support both SCAN and IBAN identifiers. Default to SCAN.
-                if (!string.IsNullOrEmpty(SortCode) && !string.IsNullOrEmpty(AccountNumber))
-                {
-                    return AccountIdentifierType.SCAN;
-                }
-                else if(!string.IsNullOrEmpty(IBAN))
-                {
-                    return AccountIdentifierType.IBAN;
-                }
-            }
-
-            if (!string.IsNullOrEmpty(IBAN))
-            {
-                return AccountIdentifierType.IBAN;
-            }
-
-            if (!string.IsNullOrEmpty(SortCode) && !string.IsNullOrEmpty(AccountNumber))
-            {
-                return AccountIdentifierType.SCAN;
-            }
-
-            if (!string.IsNullOrEmpty(BitcoinAddress))
-            {
-                return AccountIdentifierType.BTC;
-            }
-
-            // Return default
-            return AccountIdentifierType.Unknown;
-        }
-    }
 
     /// <summary>
     /// The currency for the account.
@@ -177,13 +137,10 @@ public class AccountIdentifierCreate
             { keyPrefix + nameof(BitcoinAddress), BitcoinAddress ?? string.Empty}
         };
     }
-    
+
     /// <summary>
     /// Summary of the account identifier's most important properties.
     /// </summary>
-    public string Summary =>   
-        Type == AccountIdentifierType.IBAN ? Type.ToString() + ": " + IBAN :
-        Type == AccountIdentifierType.SCAN ? Type.ToString() + ": " + SortCode + " / " + AccountNumber :
-        Type == AccountIdentifierType.BTC ? Type.ToString() + ": " + BitcoinAddress :
-        "No identifier.";
+    public string Summary =>
+        $"IBAN: {IBAN}, BIC: {BIC}, SortCode: {SortCode}, AccountNumber: {AccountNumber}, BitcoinAddress: {BitcoinAddress}";
 }

--- a/src/NoFrixion.MoneyMoov/Models/Account/AccountIdentifierCreate.cs
+++ b/src/NoFrixion.MoneyMoov/Models/Account/AccountIdentifierCreate.cs
@@ -1,25 +1,22 @@
 ﻿// -----------------------------------------------------------------------------
-//  Filename: AccountIdentifier.cs
+//  Filename: AccountIdentifierCreate.cs
 // 
-//  Description: Account identifier:
+//  Description: Account identifier Create model
 //  Author(s):
-//  Donal O'Connor (donal@nofrixion.com)
+//  saurav@nofrixion.com (saurav@nofrixion.com)
 // 
 //  History:
-//  21 10 2021  Donal O'Connor   Created, Carmichael House, Dublin, Ireland.
-//  19 09 2023  Aaron Clauson    Added Bitcoin support.
+//  16 04 2024  Saurav Maiti   Created, Harcourt street, Dublin, Ireland.
 // 
 //  License:
 //  MIT.
 // -----------------------------------------------------------------------------
 
-using System.ComponentModel.DataAnnotations;
-
 namespace NoFrixion.MoneyMoov.Models;
 
 #nullable disable
 
-public class AccountIdentifier: IValidatableObject
+public class AccountIdentifierCreate
 {
     /// <summary>
     /// The type of the account identifier.
@@ -65,7 +62,7 @@ public class AccountIdentifier: IValidatableObject
     /// <summary>
     /// The currency for the account.
     /// </summary>
-    public required CurrencyTypeEnum Currency { get; set; }
+    public CurrencyTypeEnum? Currency { get; set; }
 
     /// <summary>
     /// The Bank Identifier Code for an IBAN.
@@ -168,29 +165,6 @@ public class AccountIdentifier: IValidatableObject
         }
     }
 
-    /// <summary>
-    /// Summary of the account identifier's most important properties.
-    /// </summary>
-    public string Summary =>   
-        Type == AccountIdentifierType.IBAN ? Type.ToString() + ": " + IBAN :
-        Type == AccountIdentifierType.SCAN ? Type.ToString() + ": " + SortCode + " / " + AccountNumber :
-        Type == AccountIdentifierType.BTC ? Type.ToString() + ": " + BitcoinAddress :
-         "No identifier.";
-    
-    /// <summary>
-    /// Summary of the account identifier's most important properties.
-    /// </summary>
-    public string DisplaySummary =>   
-        Type == AccountIdentifierType.IBAN ? IBAN :
-        Type == AccountIdentifierType.SCAN ? DisplayScanSummary :
-        Type == AccountIdentifierType.BTC ? BitcoinAddress :
-        "No identifier.";
-
-    public string DisplayScanSummary =>
-        !string.IsNullOrEmpty(SortCode) && !string.IsNullOrEmpty(AccountNumber) && SortCode.Length == 6
-            ? $"{SortCode[..2]}-{SortCode.Substring(2, 2)}-{SortCode.Substring(4, 2)} {AccountNumber}"
-            : "No identifier.";
-
     public virtual Dictionary<string, string> ToDictionary(string keyPrefix)
     {
         return new Dictionary<string, string>
@@ -203,79 +177,13 @@ public class AccountIdentifier: IValidatableObject
             { keyPrefix + nameof(BitcoinAddress), BitcoinAddress ?? string.Empty}
         };
     }
-
-    public string GetApprovalHash()
-    {
-        string input =
-            Currency +
-            (!string.IsNullOrEmpty(BIC) ? BIC : string.Empty) +
-            (!string.IsNullOrEmpty(IBAN) ? IBAN : string.Empty) +
-            (!string.IsNullOrEmpty(SortCode) ? SortCode : string.Empty) +
-            (!string.IsNullOrEmpty(AccountNumber) ? AccountNumber : string.Empty) +
-            (!string.IsNullOrEmpty(BitcoinAddress) ? BitcoinAddress : string.Empty);
-        return HashHelper.CreateHash(input);
-    }
-
-    public override string ToString()
-    {
-        return $"Type: {Type}, Currency: {Currency}, BIC: {BIC}, IBAN: {IBAN}, SortCode: {SortCode}, AccountNumber: {AccountNumber}, Bitcoin Address: {BitcoinAddress}, Summary: {Summary}";
-    }
-
-    public NoFrixionProblem Validate()
-    {
-        var validationResults = new List<ValidationResult>();
-        var validationContext = new ValidationContext(this, serviceProvider: null, items: null);
-        var isValid = Validator.TryValidateObject(this, validationContext, validationResults, true);
-        
-        if (!isValid)
-        {
-            return new NoFrixionProblem($"The {nameof(AccountIdentifier)} had one or more validation errors.", validationResults);
-        }
-        
-        return NoFrixionProblem.Empty;
-    }
-
-    public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
-    {
-        switch (Currency)
-        {
-            case CurrencyTypeEnum.GBP:
-            {
-                if (string.IsNullOrEmpty(SortCode) || string.IsNullOrEmpty(AccountNumber))
-                {
-                    yield return new ValidationResult(
-                        "Sort code and account number are required for GBP account identifier.",
-                        new[] { nameof(SortCode), nameof(AccountNumber) });
-                }
-
-                break;
-            }
-            case CurrencyTypeEnum.EUR:
-            {
-                if (string.IsNullOrEmpty(IBAN))
-                {
-                    yield return new ValidationResult("IBAN is required for EUR account identifier.",
-                        new[] { nameof(IBAN) });
-                }
-
-                break;
-            }
-            case CurrencyTypeEnum.BTC:
-            {
-                if (string.IsNullOrEmpty(BitcoinAddress))
-                {
-                    yield return new ValidationResult("Bitcoin address is required for BTC account identifier.",
-                        new[] { nameof(BitcoinAddress) });
-                }
-
-                break;
-            }
-            default:
-            {
-                yield return new ValidationResult("Currency is required for account identifier.",
-                    new[] { nameof(Currency) });
-                break;
-            }
-        }
-    }
+    
+    /// <summary>
+    /// Summary of the account identifier's most important properties.
+    /// </summary>
+    public string Summary =>   
+        Type == AccountIdentifierType.IBAN ? Type.ToString() + ": " + IBAN :
+        Type == AccountIdentifierType.SCAN ? Type.ToString() + ": " + SortCode + " / " + AccountNumber :
+        Type == AccountIdentifierType.BTC ? Type.ToString() + ": " + BitcoinAddress :
+        "No identifier.";
 }

--- a/src/NoFrixion.MoneyMoov/Models/Account/CounterpartyCreate.cs
+++ b/src/NoFrixion.MoneyMoov/Models/Account/CounterpartyCreate.cs
@@ -1,0 +1,73 @@
+﻿//-----------------------------------------------------------------------------
+// Filename: CounterpartyCreate.cs
+//
+// Description: The counterparty in a transaction. For a pay in (credit) the
+// counterparty is the sender of the payment. For a pay out (debit) the 
+// counterparty is the destination for the payment.
+//
+// Author(s):
+// Saurav Maiti (saurav@nofrixion.com)
+// 
+// History:
+// 16 Apr 2024  Saurav Maiti   Created, Harcourt street, Dublin, Ireland.
+//
+// License: 
+// MIT.
+//-----------------------------------------------------------------------------
+
+namespace NoFrixion.MoneyMoov.Models;
+
+public class CounterpartyCreate
+{
+    public Guid? AccountID { get; set; }
+
+    /// <summary>
+    /// The name of the counterparty. For a person this should be their full name. For a 
+    /// company this should be their registered or trading name.
+    /// </summary>
+    public string? Name { get; set; }
+
+    /// <summary>
+    /// An email address for the counterparty. Optional to set and depending on the payment
+    /// network does not always get set for pay ins.
+    /// </summary>
+    public string? EmailAddress { get; set; }
+
+    /// An email address for the counterparty. Optional to set and depending on the payment
+    /// network does not always get set for pay ins.
+    public string? PhoneNumber { get; set; }
+
+    /// <summary>
+    /// The counterparty's account identifier. This identifier is what is used to send the payment
+    /// to them, or for a pay in is the source of the payment.
+    /// </summary>
+    public AccountIdentifierCreate? Identifier { get; set; }
+
+    public virtual Dictionary<string, string> ToDictionary(string keyPrefix)
+    {
+        var dict = new Dictionary<string, string>
+        {
+             { keyPrefix + nameof(AccountID), AccountID != null ? AccountID.Value.ToString() : string.Empty},
+             { keyPrefix + nameof(Name), Name ?? string.Empty },
+             { keyPrefix + nameof(EmailAddress), EmailAddress ?? string.Empty },
+             { keyPrefix + nameof(PhoneNumber), PhoneNumber ?? string.Empty },
+        };
+
+        if(Identifier != null)
+        {
+            var identifierDict = Identifier.ToDictionary(keyPrefix + nameof(Identifier) + ".");
+
+            dict = dict.Concat(identifierDict)
+               .ToLookup(x => x.Key, x => x.Value)
+               .ToDictionary(x => x.Key, g => g.First());
+        }
+
+        return dict;
+    }
+    
+    /// <summary>
+    /// Gets a convenient summary representation of the counterparty.
+    /// </summary>
+    public string Summary
+        => Name + (Identifier != null ? ", " + Identifier.Summary : string.Empty);
+}

--- a/src/NoFrixion.MoneyMoov/Models/Beneficiary/Beneficiary.cs
+++ b/src/NoFrixion.MoneyMoov/Models/Beneficiary/Beneficiary.cs
@@ -175,7 +175,7 @@ public class Beneficiary : IValidatableObject
             ID = Guid.NewGuid(),
             Type = Destination?.Identifier?.Type ?? AccountIdentifierType.Unknown,
             Currency = Currency,
-            Destination = Destination
+            Destination = Destination,
         };
     }
 }

--- a/src/NoFrixion.MoneyMoov/Models/Beneficiary/Beneficiary.cs
+++ b/src/NoFrixion.MoneyMoov/Models/Beneficiary/Beneficiary.cs
@@ -170,12 +170,19 @@ public class Beneficiary : IValidatableObject
     /// <returns>A new Payout object.</returns>
     public Payout ToPayout()
     {
-        return new Payout
+        var payout = new Payout
         {
             ID = Guid.NewGuid(),
             Type = Destination?.Identifier?.Type ?? AccountIdentifierType.Unknown,
             Currency = Currency,
             Destination = Destination,
         };
+
+        if (payout.Destination?.Identifier != null)
+        {
+            payout.Destination.Identifier.Currency = Currency;
+        }
+
+        return payout;
     }
 }

--- a/src/NoFrixion.MoneyMoov/Models/Beneficiary/BeneficiaryCreate.cs
+++ b/src/NoFrixion.MoneyMoov/Models/Beneficiary/BeneficiaryCreate.cs
@@ -120,7 +120,13 @@ public class BeneficiaryCreate : IValidatableObject
         return new Payout
         {
             ID = Guid.NewGuid(),
-            Type = Destination.Identifier?.Type ?? AccountIdentifierType.Unknown,
+            Type = Currency switch
+            {
+                CurrencyTypeEnum.EUR => AccountIdentifierType.IBAN,
+                CurrencyTypeEnum.GBP => AccountIdentifierType.SCAN,
+                CurrencyTypeEnum.BTC => AccountIdentifierType.BTC,
+                _ => AccountIdentifierType.Unknown
+            },
             Currency = Currency,
             Destination = Destination.ToCounterparty(Currency)
         };

--- a/src/NoFrixion.MoneyMoov/Models/Beneficiary/BeneficiaryCreate.cs
+++ b/src/NoFrixion.MoneyMoov/Models/Beneficiary/BeneficiaryCreate.cs
@@ -43,7 +43,7 @@ public class BeneficiaryCreate : IValidatableObject
     [Required(ErrorMessage = "Currency is required.")]
     public CurrencyTypeEnum Currency { get; set; }
 
-    public Counterparty Destination { get; set; }
+    public CounterpartyCreate Destination { get; set; }
 
     public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
     {
@@ -122,7 +122,7 @@ public class BeneficiaryCreate : IValidatableObject
             ID = Guid.NewGuid(),
             Type = Destination.Identifier?.Type ?? AccountIdentifierType.Unknown,
             Currency = Currency,
-            Destination = Destination
+            Destination = Destination.ToCounterparty(Currency)
         };
     }
 }

--- a/src/NoFrixion.MoneyMoov/Models/Payouts/Payout.cs
+++ b/src/NoFrixion.MoneyMoov/Models/Payouts/Payout.cs
@@ -109,7 +109,7 @@ public class Payout : IValidatableObject, IWebhookPayload
         set
         {
             Destination ??= new Counterparty();
-            Destination.Identifier ??= new AccountIdentifier();
+            Destination.Identifier ??= new AccountIdentifier{Currency = CurrencyTypeEnum.EUR};
             Destination.Identifier.IBAN = value;
         }
     }
@@ -122,7 +122,7 @@ public class Payout : IValidatableObject, IWebhookPayload
         set
         {
             Destination ??= new Counterparty();
-            Destination.Identifier ??= new AccountIdentifier();
+            Destination.Identifier ??= new AccountIdentifier { Currency = CurrencyTypeEnum.GBP };
             Destination.Identifier.AccountNumber = value;
         }
     }
@@ -135,7 +135,7 @@ public class Payout : IValidatableObject, IWebhookPayload
         set
         {
             Destination ??= new Counterparty();
-            Destination.Identifier ??= new AccountIdentifier();
+            Destination.Identifier ??= new AccountIdentifier { Currency = CurrencyTypeEnum.GBP };
             Destination.Identifier.SortCode = value;
         }
     }
@@ -214,7 +214,8 @@ public class Payout : IValidatableObject, IWebhookPayload
             {
                 IBAN = SourceAccountIban,
                 SortCode = SourceAccountSortcode,
-                AccountNumber = SourceAccountNumber
+                AccountNumber = SourceAccountNumber,
+                Currency = Currency
             };
             return srcAccountIdentifier;
         }

--- a/src/NoFrixion.MoneyMoov/Models/Payouts/PayoutCreate.cs
+++ b/src/NoFrixion.MoneyMoov/Models/Payouts/PayoutCreate.cs
@@ -59,7 +59,7 @@ public class PayoutCreate
         set
         {
             Destination ??= new Counterparty();
-            Destination.Identifier ??= new AccountIdentifier();
+            Destination.Identifier ??= new AccountIdentifier { Currency = CurrencyTypeEnum.EUR };
             Destination.Identifier.IBAN = value;
         }
     }
@@ -71,7 +71,7 @@ public class PayoutCreate
         set
         {
             Destination ??= new Counterparty();
-            Destination.Identifier ??= new AccountIdentifier();
+            Destination.Identifier ??= new AccountIdentifier { Currency = CurrencyTypeEnum.GBP };
             Destination.Identifier.AccountNumber = value;
         }
     }
@@ -83,7 +83,7 @@ public class PayoutCreate
         set
         {
             Destination ??= new Counterparty();
-            Destination.Identifier ??= new AccountIdentifier();
+            Destination.Identifier ??= new AccountIdentifier { Currency = CurrencyTypeEnum.GBP };
             Destination.Identifier.SortCode = value;
         }
     }

--- a/src/NoFrixion.MoneyMoov/Models/Payouts/PayoutCreate.cs
+++ b/src/NoFrixion.MoneyMoov/Models/Payouts/PayoutCreate.cs
@@ -47,7 +47,7 @@ public class PayoutCreate
         get => Destination?.AccountID;
         set
         {
-            Destination ??= new Counterparty();
+            Destination ??= new CounterpartyCreate();
             Destination.AccountID = value;
         }
     }
@@ -58,8 +58,8 @@ public class PayoutCreate
         get => Destination?.Identifier?.IBAN;
         set
         {
-            Destination ??= new Counterparty();
-            Destination.Identifier ??= new AccountIdentifier { Currency = CurrencyTypeEnum.EUR };
+            Destination ??= new CounterpartyCreate();
+            Destination.Identifier ??= new AccountIdentifierCreate { Currency = CurrencyTypeEnum.EUR };
             Destination.Identifier.IBAN = value;
         }
     }
@@ -70,8 +70,8 @@ public class PayoutCreate
         get => Destination?.Identifier?.AccountNumber;
         set
         {
-            Destination ??= new Counterparty();
-            Destination.Identifier ??= new AccountIdentifier { Currency = CurrencyTypeEnum.GBP };
+            Destination ??= new CounterpartyCreate();
+            Destination.Identifier ??= new AccountIdentifierCreate { Currency = CurrencyTypeEnum.GBP };
             Destination.Identifier.AccountNumber = value;
         }
     }
@@ -82,8 +82,8 @@ public class PayoutCreate
         get => Destination?.Identifier?.SortCode;
         set
         {
-            Destination ??= new Counterparty();
-            Destination.Identifier ??= new AccountIdentifier { Currency = CurrencyTypeEnum.GBP };
+            Destination ??= new CounterpartyCreate();
+            Destination.Identifier ??= new AccountIdentifierCreate { Currency = CurrencyTypeEnum.GBP };
             Destination.Identifier.SortCode = value;
         }
     }
@@ -94,19 +94,19 @@ public class PayoutCreate
         get => Destination?.Name;
         set
         {
-            Destination ??= new Counterparty();
+            Destination ??= new CounterpartyCreate();
             Destination.Name = value;
         }
     }
 
     [Obsolete("Please use Destination.")]
-    public Counterparty? DestinationAccount
+    public CounterpartyCreate? DestinationAccount
     {
         get => Destination;
         set => Destination = value;
     }
 
-    public Counterparty? Destination { get; set; }
+    public CounterpartyCreate? Destination { get; set; }
 
     /// <summary>
     /// Optional field to associate the payout with the invoice from an external 
@@ -177,7 +177,7 @@ public class PayoutCreate
             { nameof(Currency), Currency.ToString() },
             { nameof(Amount), Amount.ToString() },
             { nameof(YourReference), YourReference ?? string.Empty },
-            { nameof(TheirReference), TheirReference ?? string.Empty},
+            { nameof(TheirReference), TheirReference ?? string.Empty },
             { nameof(InvoiceID), InvoiceID ?? string.Empty },
             { nameof(AllowIncomplete), AllowIncomplete.ToString() },
             { nameof(BeneficiaryID), BeneficiaryID?.ToString() ?? string.Empty }

--- a/src/NoFrixion.MoneyMoov/Models/Payouts/PayoutUpdate.cs
+++ b/src/NoFrixion.MoneyMoov/Models/Payouts/PayoutUpdate.cs
@@ -50,7 +50,7 @@ public class PayoutUpdate
         set
         {
             Destination ??= new Counterparty();
-            Destination.Identifier ??= new AccountIdentifier();
+            Destination.Identifier ??= new AccountIdentifier { Currency = CurrencyTypeEnum.EUR };
             Destination.Identifier.IBAN = value;
         }
     }
@@ -62,7 +62,7 @@ public class PayoutUpdate
         set
         {
             Destination ??= new Counterparty();
-            Destination.Identifier ??= new AccountIdentifier();
+            Destination.Identifier ??= new AccountIdentifier { Currency = CurrencyTypeEnum.GBP };
             Destination.Identifier.AccountNumber = value;
         }
     }
@@ -74,7 +74,7 @@ public class PayoutUpdate
         set
         {
             Destination ??= new Counterparty();
-            Destination.Identifier ??= new AccountIdentifier();
+            Destination.Identifier ??= new AccountIdentifier { Currency = CurrencyTypeEnum.GBP };
             Destination.Identifier.SortCode = value;
         }
     }
@@ -104,7 +104,7 @@ public class PayoutUpdate
         set
         {
             Destination ??= new Counterparty();
-            Destination.Identifier ??= new AccountIdentifier();
+            Destination.Identifier ??= new AccountIdentifier { Currency = CurrencyTypeEnum.BTC };
             Destination.Identifier.BitcoinAddress = value;
         }
     }

--- a/src/NoFrixion.MoneyMoov/Models/Payouts/PayoutsValidator.cs
+++ b/src/NoFrixion.MoneyMoov/Models/Payouts/PayoutsValidator.cs
@@ -269,6 +269,14 @@ public static class PayoutsValidator
             yield return new ValidationResult($"Currency {payout.Currency} cannot be used with SCAN destinations.", new string[] { nameof(payout.Currency) });
         }
 
+        if (payout.Destination?.Identifier != null)
+        {
+            foreach (var err in payout.Destination.Identifier.Validate(validationContext))
+            {
+                yield return err;
+            } 
+        }
+
         if (payout.Type != AccountIdentifierType.BTC && !ValidateTheirReference(payout.TheirReference, payout.Type))
         {
             yield return new ValidationResult("Their reference must consist of at least 6 alphanumeric characters that are not all the same " +

--- a/src/NoFrixion.MoneyMoov/Models/Rules/RuleActions/SweepDestination.cs
+++ b/src/NoFrixion.MoneyMoov/Models/Rules/RuleActions/SweepDestination.cs
@@ -92,13 +92,5 @@ public class SweepDestination : Counterparty, IValidatableObject
                 new string[] { nameof(Identifier.Currency) });
         }
 
-        if (Identifier != null)
-        {
-            foreach (var err in Identifier.Validate(validationContext))
-            {
-                yield return err;
-            }
-        }
-        
     }
 }

--- a/src/NoFrixion.MoneyMoov/Models/Rules/RuleActions/SweepDestination.cs
+++ b/src/NoFrixion.MoneyMoov/Models/Rules/RuleActions/SweepDestination.cs
@@ -86,7 +86,7 @@ public class SweepDestination : Counterparty, IValidatableObject
                 new string[] { nameof(Identifier) });
         }
 
-        if (string.IsNullOrEmpty(Identifier?.Currency))
+        if (Identifier?.Currency == CurrencyTypeEnum.None)
         {
             yield return new ValidationResult($"The destination identifier currency must be set.",
                 new string[] { nameof(Identifier.Currency) });

--- a/src/NoFrixion.MoneyMoov/Models/Rules/RuleActions/SweepDestination.cs
+++ b/src/NoFrixion.MoneyMoov/Models/Rules/RuleActions/SweepDestination.cs
@@ -91,5 +91,14 @@ public class SweepDestination : Counterparty, IValidatableObject
             yield return new ValidationResult($"The destination identifier currency must be set.",
                 new string[] { nameof(Identifier.Currency) });
         }
+
+        if (Identifier != null)
+        {
+            foreach (var err in Identifier.Validate(validationContext))
+            {
+                yield return err;
+            }
+        }
+        
     }
 }

--- a/src/NoFrixion.MoneyMoov/NoFrixion.MoneyMoov.csproj
+++ b/src/NoFrixion.MoneyMoov/NoFrixion.MoneyMoov.csproj
@@ -24,4 +24,8 @@
     <PackageReference Include="Quartz" Version="3.6.2" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Compile Remove="Extensions\AccountIdentifierExtensions.cs" />
+  </ItemGroup>
+
 </Project>

--- a/src/NoFrixion.MoneyMoov/NoFrixion.MoneyMoov.csproj
+++ b/src/NoFrixion.MoneyMoov/NoFrixion.MoneyMoov.csproj
@@ -1,31 +1,27 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
-	<AssemblyVersion>1.1.247.0</AssemblyVersion>
-	<FileVersion>1.1.247.0</FileVersion>
-	<GenerateDocumentationFile>True</GenerateDocumentationFile>
-	<TreatWarningsAsErrors>True</TreatWarningsAsErrors>
-	<NoWarn>$(NoWarn);1591</NoWarn>
-  </PropertyGroup>
+    <PropertyGroup>
+        <TargetFramework>net7.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <AssemblyVersion>1.1.247.0</AssemblyVersion>
+        <FileVersion>1.1.247.0</FileVersion>
+        <GenerateDocumentationFile>True</GenerateDocumentationFile>
+        <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
+        <NoWarn>$(NoWarn);1591</NoWarn>
+    </PropertyGroup>
 
-  <ItemGroup>
-	<PackageReference Include="Ardalis.GuardClauses" Version="4.0.1" />
-	<PackageReference Include="CsvHelper" Version="30.0.1" />
-	<PackageReference Include="IdentityModel" Version="6.1.0" />
-    <PackageReference Include="LanguageExt.Core" Version="4.4.3" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="7.0.0" />
-    <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="6.35.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="Quartz" Version="3.6.2" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Compile Remove="Extensions\AccountIdentifierExtensions.cs" />
-  </ItemGroup>
+    <ItemGroup>
+        <PackageReference Include="Ardalis.GuardClauses" Version="4.0.1" />
+        <PackageReference Include="CsvHelper" Version="30.0.1" />
+        <PackageReference Include="IdentityModel" Version="6.1.0" />
+        <PackageReference Include="LanguageExt.Core" Version="4.4.3" />
+        <PackageReference Include="Microsoft.Extensions.Configuration" Version="7.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Http" Version="7.0.0" />
+        <PackageReference Include="Microsoft.Extensions.Logging" Version="7.0.0" />
+        <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="6.35.0" />
+        <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+        <PackageReference Include="Quartz" Version="3.6.2" />
+    </ItemGroup>
 
 </Project>

--- a/test/MoneyMoov.UnitTests/Mapping/AccountIdentifierMapperTests.cs
+++ b/test/MoneyMoov.UnitTests/Mapping/AccountIdentifierMapperTests.cs
@@ -1,0 +1,69 @@
+using NoFrixion.MoneyMoov.Models;
+using Xunit;
+
+namespace NoFrixion.MoneyMoov.UnitTests;
+
+public class AccountIdentifierMapperTests
+{
+    [Fact]
+    public void MapToAccountIdentifier_FromAccountIdentifierCreate_Success()
+    {
+        var accountIdentifierCreate = new AccountIdentifierCreate()
+        {
+            IBAN = "GB33BUKB20201555555555",
+            BIC = "BUKBGB22",
+            AccountNumber = "20201555555555",
+            SortCode = "202015",
+            Currency = CurrencyTypeEnum.EUR
+        };
+        
+        var accountIdentifier = accountIdentifierCreate.ToAccountIdentifier(CurrencyTypeEnum.GBP);
+        
+        Assert.Equal(accountIdentifierCreate.IBAN, accountIdentifier.IBAN);
+        Assert.Equal(accountIdentifierCreate.BIC, accountIdentifier.BIC);
+        Assert.Equal(accountIdentifierCreate.AccountNumber, accountIdentifier.AccountNumber);
+        Assert.Equal(accountIdentifierCreate.SortCode, accountIdentifier.SortCode);
+        Assert.Equal(accountIdentifierCreate.Currency, accountIdentifier.Currency);
+    }
+    
+    [Fact]
+    public void MapToAccountIdentifier_FromAccountIdentifierCreateWithoutCurrency_Success()
+    {
+        var accountIdentifierCreate = new AccountIdentifierCreate()
+        {
+            IBAN = "GB33BUKB20201555555555",
+            BIC = "BUKBGB22",
+            AccountNumber = "20201555555555",
+            SortCode = "202015"
+        };
+        
+        var accountIdentifier = accountIdentifierCreate.ToAccountIdentifier(CurrencyTypeEnum.EUR);
+        
+        Assert.Equal(accountIdentifierCreate.IBAN, accountIdentifier.IBAN);
+        Assert.Equal(accountIdentifierCreate.BIC, accountIdentifier.BIC);
+        Assert.Equal(accountIdentifierCreate.AccountNumber, accountIdentifier.AccountNumber);
+        Assert.Equal(accountIdentifierCreate.SortCode, accountIdentifier.SortCode);
+        Assert.Equal(CurrencyTypeEnum.EUR, accountIdentifier.Currency);
+    }
+    
+    [Fact]
+    public void MapToAccountIdentifierCreate_FromAccountIdentifier_Success()
+    {
+        var accountIdentifier = new AccountIdentifier()
+        {
+            IBAN = "GB33BUKB20201555555555",
+            BIC = "BUKBGB22",
+            AccountNumber = "20201555555555",
+            SortCode = "202015",
+            Currency = CurrencyTypeEnum.EUR
+        };
+        
+        var accountIdentifierCreate = accountIdentifier.ToAccountIdentifierCreate();
+        
+        Assert.Equal(accountIdentifier.IBAN, accountIdentifierCreate.IBAN);
+        Assert.Equal(accountIdentifier.BIC, accountIdentifierCreate.BIC);
+        Assert.Equal(accountIdentifier.AccountNumber, accountIdentifierCreate.AccountNumber);
+        Assert.Equal(accountIdentifier.SortCode, accountIdentifierCreate.SortCode);
+        Assert.Equal(accountIdentifier.Currency, accountIdentifierCreate.Currency);
+    }
+}

--- a/test/MoneyMoov.UnitTests/Mapping/CounterpartyMapperTests.cs
+++ b/test/MoneyMoov.UnitTests/Mapping/CounterpartyMapperTests.cs
@@ -1,0 +1,70 @@
+using NoFrixion.MoneyMoov.Models;
+using Xunit;
+
+namespace NoFrixion.MoneyMoov;
+
+public class CounterpartyMapperTests
+{
+    [Fact]
+    public void MapToCounterparty_FromCounterpartyCreate_Success()
+    {
+        var counterpartyCreate = new CounterpartyCreate()
+        {
+            AccountID = Guid.NewGuid(),
+            Name = "Test Counterparty",
+            EmailAddress = "email@email.com",
+            PhoneNumber = "1234567890",
+            Identifier = new AccountIdentifierCreate()
+            {
+                    IBAN = "GB33BUKB20201555555555",
+                    BIC = "BUKBGB22",
+                    AccountNumber = "20201555555555",
+                    SortCode = "202015",
+                    Currency = CurrencyTypeEnum.EUR
+            }
+        };
+        
+        var counterparty = counterpartyCreate.ToCounterparty(CurrencyTypeEnum.GBP);
+        
+        Assert.Equal(counterpartyCreate.AccountID, counterparty.AccountID);
+        Assert.Equal(counterpartyCreate.Name, counterparty.Name);
+        Assert.Equal(counterpartyCreate.EmailAddress, counterparty.EmailAddress);
+        Assert.Equal(counterpartyCreate.PhoneNumber, counterparty.PhoneNumber);
+        Assert.Equal(counterpartyCreate.Identifier.IBAN, counterparty.Identifier?.IBAN);
+        Assert.Equal(counterpartyCreate.Identifier.BIC, counterparty.Identifier?.BIC);
+        Assert.Equal(counterpartyCreate.Identifier.AccountNumber, counterparty.Identifier?.AccountNumber);
+        Assert.Equal(counterpartyCreate.Identifier.SortCode, counterparty.Identifier?.SortCode);
+        Assert.Equal(counterpartyCreate.Identifier.Currency, counterparty.Identifier?.Currency);
+    }
+
+    [Fact]
+    public void MapToCounterparty_FromCounterpartyCreateWithoutCurrency_Success()
+    {
+        var counterpartyCreate = new CounterpartyCreate()
+        {
+            AccountID = Guid.NewGuid(),
+            Name = "Test Counterparty",
+            EmailAddress = "email@email.com",
+            PhoneNumber = "1234567890",
+            Identifier = new AccountIdentifierCreate()
+            {
+                IBAN = "GB33BUKB20201555555555",
+                BIC = "BUKBGB22",
+                AccountNumber = "20201555555555",
+                SortCode = "202015"
+            }
+        };
+
+        var counterparty = counterpartyCreate.ToCounterparty(CurrencyTypeEnum.EUR);
+
+        Assert.Equal(counterpartyCreate.AccountID, counterparty.AccountID);
+        Assert.Equal(counterpartyCreate.Name, counterparty.Name);
+        Assert.Equal(counterpartyCreate.EmailAddress, counterparty.EmailAddress);
+        Assert.Equal(counterpartyCreate.PhoneNumber, counterparty.PhoneNumber);
+        Assert.Equal(counterpartyCreate.Identifier.IBAN, counterparty.Identifier?.IBAN);
+        Assert.Equal(counterpartyCreate.Identifier.BIC, counterparty.Identifier?.BIC);
+        Assert.Equal(counterpartyCreate.Identifier.AccountNumber, counterparty.Identifier?.AccountNumber);
+        Assert.Equal(counterpartyCreate.Identifier.SortCode, counterparty.Identifier?.SortCode);
+        Assert.Equal(CurrencyTypeEnum.EUR, counterparty.Identifier?.Currency);
+    }
+}

--- a/test/MoneyMoov.UnitTests/Models/AccountIdentifierTests.cs
+++ b/test/MoneyMoov.UnitTests/Models/AccountIdentifierTests.cs
@@ -64,4 +64,77 @@ public class AccountIdentifierTests : MoneyMoovUnitTestBase<AccountIdentifierTes
         Assert.Equal("123456", accountIdentifier.SortCode);
         Assert.Equal("00000070629907", accountIdentifier.AccountNumber);
     }
+
+    [Fact]
+    public void AccountIdentifier_Validate_EUR_Success()
+    {
+        var accountIdentifier = new AccountIdentifier
+        {
+            BIC = "MODR123",
+            IBAN = "GB42MOCK00000070629907",
+            Currency = CurrencyTypeEnum.EUR
+        };
+        
+        var validationResults = accountIdentifier.Validate();
+        
+        Assert.True(validationResults.IsEmpty);
+    }
+    
+    [Fact]
+    public void AccountIdentifier_Validate_GBP_Success()
+    {
+        var accountIdentifier = new AccountIdentifier
+        {
+            SortCode = "123456",
+            AccountNumber = "00000070629907",
+            Currency = CurrencyTypeEnum.GBP
+        };
+        
+        var validationResults = accountIdentifier.Validate();
+        
+        Assert.True(validationResults.IsEmpty);
+    }
+    
+    [Fact]
+    public void AccountIdentifier_Validate_EUR_No_IBAN_Failure()
+    {
+        var accountIdentifier = new AccountIdentifier
+        {
+            BIC = "MODR123",
+            Currency = CurrencyTypeEnum.EUR
+        };
+        
+        var validationResults = accountIdentifier.Validate();
+        
+        Assert.False(validationResults.IsEmpty);
+    }
+    
+    [Fact]
+    public void AccountIdentifier_Validate_GBP_No_SortCode_Failure()
+    {
+        var accountIdentifier = new AccountIdentifier
+        {
+            AccountNumber = "00000070629907",
+            Currency = CurrencyTypeEnum.GBP
+        };
+        
+        var validationResults = accountIdentifier.Validate();
+        
+        Assert.False(validationResults.IsEmpty);
+    }
+    
+    [Fact]
+    public void AccountIdentifier_Validate_GBP_No_AccountNumber_Failure()
+    {
+        var accountIdentifier = new AccountIdentifier
+        {
+            SortCode = "123456",
+            Currency = CurrencyTypeEnum.GBP
+        };
+        
+        var validationResults = accountIdentifier.Validate();
+        
+        Assert.False(validationResults.IsEmpty);
+    }
+    
 }

--- a/test/MoneyMoov.UnitTests/Models/AccountIdentifierTests.cs
+++ b/test/MoneyMoov.UnitTests/Models/AccountIdentifierTests.cs
@@ -36,7 +36,8 @@ public class AccountIdentifierTests : MoneyMoovUnitTestBase<AccountIdentifierTes
         var accountIdentifier = new AccountIdentifier
         {
             BIC = "  MODR  123 ",
-            IBAN = " GB42MO CK00000070629 907 "
+            IBAN = " GB42MO CK00000070629 907 ",
+            Currency = CurrencyTypeEnum.EUR
         };
 
         Assert.Equal(AccountIdentifierType.IBAN, accountIdentifier.Type);
@@ -55,7 +56,8 @@ public class AccountIdentifierTests : MoneyMoovUnitTestBase<AccountIdentifierTes
         var accountIdentifier = new AccountIdentifier
         {
             SortCode = " 12 34 56 ",
-            AccountNumber = " 00000070629 907 "
+            AccountNumber = " 00000070629 907 ",
+            Currency = CurrencyTypeEnum.EUR
         };
 
         Assert.Equal(AccountIdentifierType.SCAN, accountIdentifier.Type);

--- a/test/MoneyMoov.UnitTests/Models/BeneficiarySerialisationTests.cs
+++ b/test/MoneyMoov.UnitTests/Models/BeneficiarySerialisationTests.cs
@@ -98,7 +98,9 @@ public class BeneficiarySerialisationTests : MoneyMoovUnitTestBase<BeneficiarySe
                     ""identifier"":{
                         ""type"":""IBAN"",
                         ""iban"":""GB33BUKB20201555555555"",
-                        ""summary"":""IBAN: GB33BUKB20201555555555""
+                        ""summary"":""IBAN: GB33BUKB20201555555555"",
+                        ""currency"":""EUR""
+                        
                 }}  
             }";
 

--- a/test/MoneyMoov.UnitTests/Models/BeneficiaryValidationTests.cs
+++ b/test/MoneyMoov.UnitTests/Models/BeneficiaryValidationTests.cs
@@ -44,7 +44,8 @@ public class BeneficairyValidationTests : MoneyMoovUnitTestBase<BeneficairyValid
                 Name = "Test Dest",
                 Identifier = new AccountIdentifier
                 {
-                    IBAN = "GB42MOCK00000070629907"
+                    IBAN = "GB42MOCK00000070629907",
+                    Currency = CurrencyTypeEnum.EUR
                 }
             }
         };

--- a/test/MoneyMoov.UnitTests/Models/PayoutsValidatorTests.cs
+++ b/test/MoneyMoov.UnitTests/Models/PayoutsValidatorTests.cs
@@ -151,7 +151,8 @@ public class PayoutsValidatorTests
                 Name = "Joe Bloggs",
                 Identifier = new AccountIdentifier
                 {
-                    IBAN = "IE36ULSB98501017331006"
+                    IBAN = "IE36ULSB98501017331006",
+                    Currency = CurrencyTypeEnum.EUR
                 }
             }
         };

--- a/test/MoneyMoov.UnitTests/Models/PayoutsValidatorTests.cs
+++ b/test/MoneyMoov.UnitTests/Models/PayoutsValidatorTests.cs
@@ -251,4 +251,144 @@ public class PayoutsValidatorTests
         _logger.LogDebug(yourReference);
         _logger.LogDebug("Your reference length={YourReferenceLength}", yourReference.Length);
     }
+
+    [Fact]
+    public void PayoutsValidator_Validate_EUR_Destination_Identifier_Success()
+    {
+        var destination = new Counterparty
+        {
+            Name = "Joe Bloggs",
+            Identifier = new AccountIdentifier
+            {
+                IBAN = "GB42MOCK00000070629907",
+                Currency = CurrencyTypeEnum.EUR
+            }
+        };
+        
+        var payout = new Payout
+        {
+            ID = Guid.NewGuid(),
+            AccountID = Guid.Parse("B2DBB4E1-5F8A-4B07-82A0-EB033E6F3421"),
+            Type = AccountIdentifierType.IBAN,
+            Description = "Xero Invoice fgfg from Demo Company (Global).",
+            Currency = CurrencyTypeEnum.EUR,
+            Amount = 11.00M,
+            YourReference = "xero-18ead957-e3bc-4b12-b5c6-d12e4bef9d24",
+            TheirReference = "Placeholder",
+            Status = PayoutStatus.PENDING_INPUT,
+            InvoiceID = "18ead957-e3bc-4b12-b5c6-d12e4bef9d24",
+            Destination = destination
+        };
+        
+        var result = payout.Validate();
+        
+        _logger.LogDebug(result.ToTextErrorMessage());
+        
+        Assert.True(result.IsEmpty);
+    }
+    
+    [Fact]
+    public void PayoutsValidator_Validate_GBP_Destination_Identifier_Success()
+    {
+        var destination = new Counterparty
+        {
+            Name = "Joe Bloggs",
+            Identifier = new AccountIdentifier
+            {
+                SortCode = "123456",
+                AccountNumber = "00000070629907",
+                Currency = CurrencyTypeEnum.GBP
+            }
+        };
+        
+        var payout = new Payout
+        {
+            ID = Guid.NewGuid(),
+            AccountID = Guid.Parse("B2DBB4E1-5F8A-4B07-82A0-EB033E6F3421"),
+            Type = AccountIdentifierType.SCAN,
+            Description = "Xero Invoice fgfg from Demo Company (Global).",
+            Currency = CurrencyTypeEnum.GBP,
+            Amount = 11.00M,
+            YourReference = "xero-18ead957-e3bc-4b12-b5c6-d12e4bef9d24",
+            TheirReference = "Placeholder",
+            Status = PayoutStatus.PENDING_INPUT,
+            InvoiceID = "18ead957-e3bc-4b12-b5c6-d12e4bef9d24",
+            Destination = destination
+        };
+        
+        var result = payout.Validate();
+        
+        _logger.LogDebug(result.ToTextErrorMessage());
+        
+        Assert.True(result.IsEmpty);
+    }
+    
+    [Fact]
+    public void PayoutsValidator_Validate_EUR_Destination_Identifier_Failure()
+    {
+        var destination = new Counterparty
+        {
+            Name = "Joe Bloggs",
+            Identifier = new AccountIdentifier
+            {
+                Currency = CurrencyTypeEnum.EUR
+            }
+        };
+        
+        var payout = new Payout
+        {
+            ID = Guid.NewGuid(),
+            AccountID = Guid.Parse("B2DBB4E1-5F8A-4B07-82A0-EB033E6F3421"),
+            Type = AccountIdentifierType.IBAN,
+            Description = "Xero Invoice fgfg from Demo Company (Global).",
+            Currency = CurrencyTypeEnum.EUR,
+            Amount = 11.00M,
+            YourReference = "xero-18ead957-e3bc-4b12-b5c6-d12e4bef9d24",
+            TheirReference = "Placeholder",
+            Status = PayoutStatus.PENDING_INPUT,
+            InvoiceID = "18ead957-e3bc-4b12-b5c6-d12e4bef9d24",
+            Destination = destination
+        };
+        
+        var result = payout.Validate();
+        
+        _logger.LogDebug(result.ToTextErrorMessage());
+        
+        Assert.False(result.IsEmpty);
+    }
+    
+    [Fact]
+    public void PayoutsValidator_Validate_GBP_Destination_Identifier_Failure()
+    {
+        var destination = new Counterparty
+        {
+            Name = "Joe Bloggs",
+            Identifier = new AccountIdentifier
+            {
+                Currency = CurrencyTypeEnum.GBP
+            }
+        };
+        
+        var payout = new Payout
+        {
+            ID = Guid.NewGuid(),
+            AccountID = Guid.Parse("B2DBB4E1-5F8A-4B07-82A0-EB033E6F3421"),
+            Type = AccountIdentifierType.SCAN,
+            Description = "Xero Invoice fgfg from Demo Company (Global).",
+            Currency = CurrencyTypeEnum.GBP,
+            Amount = 11.00M,
+            YourReference = "xero-18ead957-e3bc-4b12-b5c6-d12e4bef9d24",
+            TheirReference = "Placeholder",
+            Status = PayoutStatus.PENDING_INPUT,
+            InvoiceID = "18ead957-e3bc-4b12-b5c6-d12e4bef9d24",
+            Destination = destination
+        };
+        
+        var result = payout.Validate();
+        
+        _logger.LogDebug(result.ToTextErrorMessage());
+        
+        Assert.False(result.IsEmpty);
+    }
+    
 }

--- a/test/MoneyMoov.UnitTests/Models/RuleValidationTests.cs
+++ b/test/MoneyMoov.UnitTests/Models/RuleValidationTests.cs
@@ -25,48 +25,6 @@ public class RuleValidationTests : MoneyMoovUnitTestBase<RuleValidationTests>
     public RuleValidationTests(ITestOutputHelper testOutputHelper) : base(testOutputHelper)
     { }
 
-    /// <summary>
-    /// Tests that a sweep rule generates a validation error if the currency is not set.
-    /// </summary>
-    [Fact]
-    public void Rule_No_Identifier_Currency_Validation_Fails()
-    {
-        Logger.LogDebug($"--> {TypeExtensions.GetCaller()}.");
-
-        var rule = new Rule
-        {
-            SweepAction = new SweepAction
-            {
-                Priority = 1,
-                AmountToLeave = 1.00M,
-                MinimumAmountToRunAt = 99.00M,
-                Destinations = new List<SweepDestination>
-                {
-                    new SweepDestination
-                    {
-                        SweepPercentage = 100,
-                        Name = "Jane Doe",
-                        Identifier = new AccountIdentifier
-                        {
-                            IBAN = "IEMOCK123456779"
-                        }
-                    }
-                }
-            }
-        };
-
-        var problem = rule.Validate();
-
-        Assert.NotNull(problem);
-
-        foreach (var err in problem.Errors)
-        {
-            Logger.LogDebug(Newtonsoft.Json.JsonConvert.SerializeObject(err));
-        }
-
-        Assert.NotEmpty(problem.Errors);
-    }
-
     [Theory]
     [InlineData("0 0/15 * * * ?", false)] // Will fail as the new value is less than 60 minutes.
     [InlineData("0 0/10 * * * ?", false)] // Will fail as the new value is less than 60 minutes.
@@ -94,7 +52,7 @@ public class RuleValidationTests : MoneyMoovUnitTestBase<RuleValidationTests>
                         Name = "Jane Doe",
                         Identifier = new AccountIdentifier
                         {
-                            Currency = "EUR",
+                            Currency = CurrencyTypeEnum.EUR,
                             IBAN = "IEMOCK123456779"
                         }
                     }


### PR DESCRIPTION
- Made currency property in AccountIdentifier model as required.
- Added AccountIdentifierCreate and CounterpartyCreate models to be used in PayoutCreate and BeneficiaryCreate models for backward compatibility.
- Added mappers for new models. If currency is passed in the create models, it is given priority but if not then, the currency of the parent is set to account identifier.