### PR TITLE
Moved the mult-dest check from counterparty. 

### DIFF
--- a/src/NoFrixion.MoneyMoov/Models/Rules/Rule.cs
+++ b/src/NoFrixion.MoneyMoov/Models/Rules/Rule.cs
@@ -21,6 +21,11 @@ namespace NoFrixion.MoneyMoov.Models;
 
 public class Rule : IValidatableObject, IWebhookPayload
 {
+    /// <summary>
+    /// The minimum interval between rule executions in minutes.
+    /// </summary>
+    public const int MINIMUM_CRON_INTERVAL_MINUTES = 1;
+
     public Guid ID { get; set; }
     public Guid AccountID { get; set; }
 
@@ -138,10 +143,9 @@ public class Rule : IValidatableObject, IWebhookPayload
             }
             else
             {
-                const int MIN_CRON_INTERVAL_MINUTES = 60;
-                if (!IsCronExpressionScheduledMoreThanXMinutes(TriggerCronExpression, MIN_CRON_INTERVAL_MINUTES))
+                if (!IsCronExpressionScheduledMoreThanXMinutes(TriggerCronExpression, MINIMUM_CRON_INTERVAL_MINUTES))
                 {
-                    yield return new ValidationResult($"Invalid TriggerCronExpression. The minimum interval between rule executions is {MIN_CRON_INTERVAL_MINUTES} minutes.",
+                    yield return new ValidationResult($"Invalid TriggerCronExpression. The minimum interval between rule executions is {MINIMUM_CRON_INTERVAL_MINUTES} minutes.",
                         new string[] { nameof(TriggerCronExpression) });
                 }
             }

--- a/src/NoFrixion.MoneyMoov/Models/Transaction/Counterparty.cs
+++ b/src/NoFrixion.MoneyMoov/Models/Transaction/Counterparty.cs
@@ -72,7 +72,7 @@ public class Counterparty
         (!string.IsNullOrEmpty(Identifier.AccountNumber) && !string.IsNullOrEmpty(Identifier.SortCode)) ||  
         !string.IsNullOrEmpty(Identifier.BitcoinAddress));
 
-    private int DestinationsSetCount() =>
+    public int DestinationsSetCount() =>
         (IsAccountIDSet() ? 1 : 0) + (IsBeneficiaryIDSet() ? 1 : 0) + (IsIdentifierSet() ? 1 : 0);
 
     public bool IsSameDestination(Counterparty? other)
@@ -141,12 +141,6 @@ public class Counterparty
         {
             yield return new ValidationResult($"One of the destination options (AccountID, BeneficiaryID or Identifier) must be set for a counterparty.",
                 null);
-        }
-
-        if (DestinationsSetCount() > 1)
-        {
-            yield return new ValidationResult($"Only one of the destination options (AccountID, BeneficiaryID or Identifier) can be set for a counterparty.",
-               null);
         }
 
         if (IsIdentifierSet() && Identifier?.Type == AccountIdentifierType.Unknown)


### PR DESCRIPTION
It makes sense for the counterparty to set the identifer details from the AccountID or BeneficiaryID so relocated that validation rule. 

Reduced min interval from 60 minutes to 1 minute.