### PR TITLE
Added user minimal model to return authoriser info

### DIFF
--- a/src/NoFrixion.MoneyMoov/Models/Beneficiary/Beneficiary.cs
+++ b/src/NoFrixion.MoneyMoov/Models/Beneficiary/Beneficiary.cs
@@ -54,9 +54,9 @@ public class Beneficiary : IValidatableObject
     public bool IsEnabled { get; set; }
     
     /// <summary>
-    /// A list of the email addresses of all the users who have usccessfully authorised the latest version of the beneficiary.
+    /// A list of users who have successfully authorised the latest version of the beneficiary.
     /// </summary>
-    [CanBeNull] public List<string> AuthorisedBy { get; set; }
+    [CanBeNull] public List<UserMinimal> AuthorisedBy { get; set; }
 
     /// <summary>
     /// True if the beneficiary can be authorised by the user who loaded it.

--- a/src/NoFrixion.MoneyMoov/Models/User/UserMinimal.cs
+++ b/src/NoFrixion.MoneyMoov/Models/User/UserMinimal.cs
@@ -1,0 +1,25 @@
+// -----------------------------------------------------------------------------
+//  Filename: UserMinimal.cs
+// 
+//  Description: Model containing basic user info.
+//
+//  Author(s):
+//  Saurav Maiti (saurav@nofrixion.com)
+// 
+//  History:
+//  07 Jun 2024  Saurav Maiti  Created, Harcourt Street, Dublin, Ireland.
+// 
+//  License:
+//  Proprietary NoFrixion.
+// -----------------------------------------------------------------------------
+
+namespace NoFrixion.MoneyMoov.Models;
+
+public class UserMinimal
+{
+    public Guid ID { get; set; }
+    
+    public string Name { get; set; } = string.Empty;
+    
+    public string EmailAddress { get; set; } = string.Empty;
+}


### PR DESCRIPTION
- Added a new UserMinimal model to return basic info about the user that is often required on the MM4B. Didn't want to return the entire User model. If this is not correct, I will return the User model in that case.