### PR TITLE
Make JSON serialisation consistent

### DIFF
--- a/src/NoFrixion.MoneyMoov/ApiClients/MetadataClient.cs
+++ b/src/NoFrixion.MoneyMoov/ApiClients/MetadataClient.cs
@@ -121,7 +121,7 @@ public class MetadataClient : IMetadataClient
     /// <returns>A JSON echo response message.</returns>
     public Task<RestApiResponse<dynamic>> EchoJsonAsync(string name, string message)
     {
-        var content = JsonContent.Create(new { name, message });
+        var content = new { name, message }.ToJsonContent();
         return _apiClient.PostAsync<dynamic>(MoneyMoovUrlBuilder.MetadataApi.EchoUrl(_apiClient.GetBaseUri().ToString()), content);
     }
 }

--- a/src/NoFrixion.MoneyMoov/ApiClients/MetadataClient.cs
+++ b/src/NoFrixion.MoneyMoov/ApiClients/MetadataClient.cs
@@ -18,7 +18,6 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using NoFrixion.MoneyMoov.Models;
 using System.Net;
-using System.Net.Http.Json;
 
 namespace NoFrixion.MoneyMoov;
 
@@ -32,7 +31,7 @@ public interface IMetadataClient
 
     Task<RestApiResponse<string>> EchoAsync(string name, string message);
 
-    Task<RestApiResponse<dynamic>> EchoJsonAsync(string name, string message);
+    Task<RestApiResponse<EchoMessage>> EchoJsonAsync(string name, string message);
 }
 
 public class MetadataClient : IMetadataClient
@@ -119,9 +118,9 @@ public class MetadataClient : IMetadataClient
     /// Calls the MoneyMoov Metadata get version endpoint with a JSON encoded payload.
     /// </summary>
     /// <returns>A JSON echo response message.</returns>
-    public Task<RestApiResponse<dynamic>> EchoJsonAsync(string name, string message)
+    public Task<RestApiResponse<EchoMessage>> EchoJsonAsync(string name, string message)
     {
         var content = new { name, message }.ToJsonContent();
-        return _apiClient.PostAsync<dynamic>(MoneyMoovUrlBuilder.MetadataApi.EchoUrl(_apiClient.GetBaseUri().ToString()), content);
+        return _apiClient.PostAsync<EchoMessage>(MoneyMoovUrlBuilder.MetadataApi.EchoUrl(_apiClient.GetBaseUri().ToString()), content);
     }
 }

--- a/src/NoFrixion.MoneyMoov/ApiClients/PayoutClient.cs
+++ b/src/NoFrixion.MoneyMoov/ApiClients/PayoutClient.cs
@@ -196,7 +196,7 @@ public class PayoutClient : IPayoutClient
 
         return prob switch
         {
-            var p when p.IsEmpty => _apiClient.PostAsync<BatchPayout>(url, userAccessToken, JsonContent.Create(payoutIDs)),
+            var p when p.IsEmpty => _apiClient.PostAsync<BatchPayout>(url, userAccessToken, payoutIDs.ToJsonContent()),
             _ => Task.FromResult(new RestApiResponse<BatchPayout>(HttpStatusCode.PreconditionFailed, new Uri(url), prob))
         };
     }

--- a/src/NoFrixion.MoneyMoov/ApiClients/UserClient.cs
+++ b/src/NoFrixion.MoneyMoov/ApiClients/UserClient.cs
@@ -59,7 +59,7 @@ public class UserClient : IUserClient
     }
 
     /// <summary>
-    /// Calls the MoneyMoov Merchant get user endpoint create a new user record.
+    /// Calls the MoneyMoov User endpoint create a new user record.
     /// </summary>
     /// <param name="userCreate">The model containing the data about the new user to create.</param>
     /// <returns>If successful, a user object.</returns>

--- a/src/NoFrixion.MoneyMoov/Enums/AccountIdentifierType.cs
+++ b/src/NoFrixion.MoneyMoov/Enums/AccountIdentifierType.cs
@@ -12,15 +12,14 @@
 //  MIT.
 // -----------------------------------------------------------------------------
 
-using Newtonsoft.Json;
-using Newtonsoft.Json.Converters;
+using System.Text.Json.Serialization;
 
 namespace NoFrixion.MoneyMoov;
 
 /// <summary>
 /// Defines the different types of account identifiers that are supported.
 /// </summary>
-[JsonConverter(typeof(StringEnumConverter))]
+[JsonConverter(typeof(JsonStringEnumConverter))]
 public enum AccountIdentifierType
 {
     /// <summary>

--- a/src/NoFrixion.MoneyMoov/Enums/AccountIdentifierType.cs
+++ b/src/NoFrixion.MoneyMoov/Enums/AccountIdentifierType.cs
@@ -12,14 +12,11 @@
 //  MIT.
 // -----------------------------------------------------------------------------
 
-using System.Text.Json.Serialization;
-
 namespace NoFrixion.MoneyMoov;
 
 /// <summary>
 /// Defines the different types of account identifiers that are supported.
 /// </summary>
-[JsonConverter(typeof(JsonStringEnumConverter))]
 public enum AccountIdentifierType
 {
     /// <summary>

--- a/src/NoFrixion.MoneyMoov/Enums/AccountStatus.cs
+++ b/src/NoFrixion.MoneyMoov/Enums/AccountStatus.cs
@@ -12,11 +12,8 @@
 //  MIT.
 // -----------------------------------------------------------------------------
 
-using System.Text.Json.Serialization;
-
 namespace NoFrixion.MoneyMoov;
 
-[JsonConverter(typeof(JsonStringEnumConverter))]
 public enum AccountStatus
 {
     ACTIVE = 1,

--- a/src/NoFrixion.MoneyMoov/Enums/AccountStatus.cs
+++ b/src/NoFrixion.MoneyMoov/Enums/AccountStatus.cs
@@ -12,12 +12,11 @@
 //  MIT.
 // -----------------------------------------------------------------------------
 
-using Newtonsoft.Json;
-using Newtonsoft.Json.Converters;
+using System.Text.Json.Serialization;
 
 namespace NoFrixion.MoneyMoov;
 
-[JsonConverter(typeof(StringEnumConverter))]
+[JsonConverter(typeof(JsonStringEnumConverter))]
 public enum AccountStatus
 {
     ACTIVE = 1,

--- a/src/NoFrixion.MoneyMoov/Enums/AddressTypesEnum.cs
+++ b/src/NoFrixion.MoneyMoov/Enums/AddressTypesEnum.cs
@@ -13,14 +13,11 @@
 // Proprietary NoFrixion.
 //-----------------------------------------------------------------------------
 
-using System.Text.Json.Serialization;
-
 namespace NoFrixion.MoneyMoov;
 
 /// <summary>
 /// Lists the supported address types.
 /// </summary>
-[JsonConverter(typeof(JsonStringEnumConverter))]
 public enum AddressTypesEnum
 {
     Unknown = 0,

--- a/src/NoFrixion.MoneyMoov/Enums/AddressTypesEnum.cs
+++ b/src/NoFrixion.MoneyMoov/Enums/AddressTypesEnum.cs
@@ -13,11 +13,14 @@
 // Proprietary NoFrixion.
 //-----------------------------------------------------------------------------
 
+using System.Text.Json.Serialization;
+
 namespace NoFrixion.MoneyMoov;
 
 /// <summary>
 /// Lists the supported address types.
 /// </summary>
+[JsonConverter(typeof(JsonStringEnumConverter))]
 public enum AddressTypesEnum
 {
     Unknown = 0,

--- a/src/NoFrixion.MoneyMoov/Enums/ApprovalTypesEnum.cs
+++ b/src/NoFrixion.MoneyMoov/Enums/ApprovalTypesEnum.cs
@@ -13,8 +13,11 @@
 //  Proprietary NoFrixion.
 // -----------------------------------------------------------------------------
 
+using System.Text.Json.Serialization;
+
 namespace NoFrixion.MoneyMoov.Enums;
 
+[JsonConverter(typeof(JsonStringEnumConverter))]
 public enum ApproveTypesEnum
 {
     None = 0,

--- a/src/NoFrixion.MoneyMoov/Enums/ApprovalTypesEnum.cs
+++ b/src/NoFrixion.MoneyMoov/Enums/ApprovalTypesEnum.cs
@@ -13,11 +13,8 @@
 //  Proprietary NoFrixion.
 // -----------------------------------------------------------------------------
 
-using System.Text.Json.Serialization;
-
 namespace NoFrixion.MoneyMoov.Enums;
 
-[JsonConverter(typeof(JsonStringEnumConverter))]
 public enum ApproveTypesEnum
 {
     None = 0,

--- a/src/NoFrixion.MoneyMoov/Enums/AuthenticationTypesEnum.cs
+++ b/src/NoFrixion.MoneyMoov/Enums/AuthenticationTypesEnum.cs
@@ -14,11 +14,8 @@
 // Proprietary NoFrixion.
 //-----------------------------------------------------------------------------
 
-using System.Text.Json.Serialization;
-
 namespace NoFrixion.MoneyMoov.Enums;
 
-[JsonConverter(typeof(JsonStringEnumConverter))]
 public enum AuthenticationTypesEnum
 {
     None = 0,

--- a/src/NoFrixion.MoneyMoov/Enums/AuthenticationTypesEnum.cs
+++ b/src/NoFrixion.MoneyMoov/Enums/AuthenticationTypesEnum.cs
@@ -14,8 +14,11 @@
 // Proprietary NoFrixion.
 //-----------------------------------------------------------------------------
 
+using System.Text.Json.Serialization;
+
 namespace NoFrixion.MoneyMoov.Enums;
 
+[JsonConverter(typeof(JsonStringEnumConverter))]
 public enum AuthenticationTypesEnum
 {
     None = 0,

--- a/src/NoFrixion.MoneyMoov/Enums/BeneficiaryAuthoriseStatusEnum.cs
+++ b/src/NoFrixion.MoneyMoov/Enums/BeneficiaryAuthoriseStatusEnum.cs
@@ -13,12 +13,11 @@
 //  MIT.
 // -----------------------------------------------------------------------------
 
-using Newtonsoft.Json;
-using Newtonsoft.Json.Converters;
+using System.Text.Json.Serialization;
 
 namespace NoFrixion.MoneyMoov.Enums;
 
-[JsonConverter(typeof(StringEnumConverter))]
+[JsonConverter(typeof(JsonStringEnumConverter))]
 public enum BeneficiaryAuthoriseStatusEnum
 {
     

--- a/src/NoFrixion.MoneyMoov/Enums/BeneficiaryAuthoriseStatusEnum.cs
+++ b/src/NoFrixion.MoneyMoov/Enums/BeneficiaryAuthoriseStatusEnum.cs
@@ -13,11 +13,8 @@
 //  MIT.
 // -----------------------------------------------------------------------------
 
-using System.Text.Json.Serialization;
-
 namespace NoFrixion.MoneyMoov.Enums;
 
-[JsonConverter(typeof(JsonStringEnumConverter))]
 public enum BeneficiaryAuthoriseStatusEnum
 {
     

--- a/src/NoFrixion.MoneyMoov/Enums/BeneficiaryEventTypeEnum.cs
+++ b/src/NoFrixion.MoneyMoov/Enums/BeneficiaryEventTypeEnum.cs
@@ -14,11 +14,8 @@
 //  MIT.
 // -----------------------------------------------------------------------------
 
-using System.Text.Json.Serialization;
-
 namespace NoFrixion.MoneyMoov.Enums;
 
-[JsonConverter(typeof(JsonStringEnumConverter))]
 public enum BeneficiaryEventTypeEnum
 {
     /// <summary>

--- a/src/NoFrixion.MoneyMoov/Enums/BeneficiaryEventTypeEnum.cs
+++ b/src/NoFrixion.MoneyMoov/Enums/BeneficiaryEventTypeEnum.cs
@@ -14,8 +14,11 @@
 //  MIT.
 // -----------------------------------------------------------------------------
 
+using System.Text.Json.Serialization;
+
 namespace NoFrixion.MoneyMoov.Enums;
 
+[JsonConverter(typeof(JsonStringEnumConverter))]
 public enum BeneficiaryEventTypeEnum
 {
     /// <summary>

--- a/src/NoFrixion.MoneyMoov/Enums/CardTokenCreateEnum.cs
+++ b/src/NoFrixion.MoneyMoov/Enums/CardTokenCreateEnum.cs
@@ -13,11 +13,8 @@
 //  License: MIT
 // -----------------------------------------------------------------------------
 
-using System.Text.Json.Serialization;
-
 namespace NoFrixion.MoneyMoov;
 
-[JsonConverter(typeof(JsonStringEnumConverter))]
 public enum CardTokenCreateModes
 {
     /// <summary>

--- a/src/NoFrixion.MoneyMoov/Enums/CardTokenCreateEnum.cs
+++ b/src/NoFrixion.MoneyMoov/Enums/CardTokenCreateEnum.cs
@@ -13,8 +13,11 @@
 //  License: MIT
 // -----------------------------------------------------------------------------
 
+using System.Text.Json.Serialization;
+
 namespace NoFrixion.MoneyMoov;
 
+[JsonConverter(typeof(JsonStringEnumConverter))]
 public enum CardTokenCreateModes
 {
     /// <summary>

--- a/src/NoFrixion.MoneyMoov/Enums/CurrencyTypeEnum.cs
+++ b/src/NoFrixion.MoneyMoov/Enums/CurrencyTypeEnum.cs
@@ -15,11 +15,9 @@
 // -----------------------------------------------------------------------------
 
 using System.Runtime.Serialization;
-using System.Text.Json.Serialization;
 
 namespace NoFrixion.MoneyMoov;
 
-[JsonConverter(typeof(JsonStringEnumConverter))]
 public enum CurrencyTypeEnum
 {
     [EnumMember(Value = "NONE")]

--- a/src/NoFrixion.MoneyMoov/Enums/CurrencyTypeEnum.cs
+++ b/src/NoFrixion.MoneyMoov/Enums/CurrencyTypeEnum.cs
@@ -15,9 +15,11 @@
 // -----------------------------------------------------------------------------
 
 using System.Runtime.Serialization;
+using System.Text.Json.Serialization;
 
 namespace NoFrixion.MoneyMoov;
 
+[JsonConverter(typeof(JsonStringEnumConverter))]
 public enum CurrencyTypeEnum
 {
     [EnumMember(Value = "NONE")]

--- a/src/NoFrixion.MoneyMoov/Enums/JurisdictionEnum.cs
+++ b/src/NoFrixion.MoneyMoov/Enums/JurisdictionEnum.cs
@@ -15,10 +15,11 @@
 //-----------------------------------------------------------------------------
 
 using System.ComponentModel.DataAnnotations;
-using System.Xml.Linq;
+using System.Text.Json.Serialization;
 
 namespace NoFrixion.MoneyMoov;
 
+[JsonConverter(typeof(JsonStringEnumConverter))]
 public enum JurisdictionEnum
 {
     /// <summary>

--- a/src/NoFrixion.MoneyMoov/Enums/JurisdictionEnum.cs
+++ b/src/NoFrixion.MoneyMoov/Enums/JurisdictionEnum.cs
@@ -15,11 +15,9 @@
 //-----------------------------------------------------------------------------
 
 using System.ComponentModel.DataAnnotations;
-using System.Text.Json.Serialization;
 
 namespace NoFrixion.MoneyMoov;
 
-[JsonConverter(typeof(JsonStringEnumConverter))]
 public enum JurisdictionEnum
 {
     /// <summary>

--- a/src/NoFrixion.MoneyMoov/Enums/MerchantMandateStatusEnum.cs
+++ b/src/NoFrixion.MoneyMoov/Enums/MerchantMandateStatusEnum.cs
@@ -13,8 +13,11 @@
 //  MIT.
 // -----------------------------------------------------------------------------
 
+using System.Text.Json.Serialization;
+
 namespace NoFrixion.MoneyMoov;
 
+[JsonConverter(typeof(JsonStringEnumConverter))]
 public enum MerchantMandateStatusEnum
 {
     /// <summary>

--- a/src/NoFrixion.MoneyMoov/Enums/MerchantMandateStatusEnum.cs
+++ b/src/NoFrixion.MoneyMoov/Enums/MerchantMandateStatusEnum.cs
@@ -13,11 +13,8 @@
 //  MIT.
 // -----------------------------------------------------------------------------
 
-using System.Text.Json.Serialization;
-
 namespace NoFrixion.MoneyMoov;
 
-[JsonConverter(typeof(JsonStringEnumConverter))]
 public enum MerchantMandateStatusEnum
 {
     /// <summary>

--- a/src/NoFrixion.MoneyMoov/Enums/MerchantTokenPermissionsEnum.cs
+++ b/src/NoFrixion.MoneyMoov/Enums/MerchantTokenPermissionsEnum.cs
@@ -14,12 +14,9 @@
 //  MIT.
 // -----------------------------------------------------------------------------
 
-using System.Text.Json.Serialization;
-
 namespace NoFrixion.MoneyMoov;
 
 [Flags]
-[JsonConverter(typeof(JsonStringEnumConverter))]
 public enum MerchantTokenPermissionsEnum
 {
     /// <summary>

--- a/src/NoFrixion.MoneyMoov/Enums/MerchantTokenPermissionsEnum.cs
+++ b/src/NoFrixion.MoneyMoov/Enums/MerchantTokenPermissionsEnum.cs
@@ -14,9 +14,12 @@
 //  MIT.
 // -----------------------------------------------------------------------------
 
+using System.Text.Json.Serialization;
+
 namespace NoFrixion.MoneyMoov;
 
 [Flags]
+[JsonConverter(typeof(JsonStringEnumConverter))]
 public enum MerchantTokenPermissionsEnum
 {
     /// <summary>

--- a/src/NoFrixion.MoneyMoov/Enums/OpenBankingOperationTypeEnum.cs
+++ b/src/NoFrixion.MoneyMoov/Enums/OpenBankingOperationTypeEnum.cs
@@ -12,9 +12,12 @@
 //  License: MIT
 // -----------------------------------------------------------------------------
 
+using System.Text.Json.Serialization;
+
 namespace NoFrixion.MoneyMoov.Enums;
 
 [Flags]
+[JsonConverter(typeof(JsonStringEnumConverter))]
 public enum OpenBankingOperationTypeEnum
 {
     /// <summary>

--- a/src/NoFrixion.MoneyMoov/Enums/OpenBankingOperationTypeEnum.cs
+++ b/src/NoFrixion.MoneyMoov/Enums/OpenBankingOperationTypeEnum.cs
@@ -12,12 +12,9 @@
 //  License: MIT
 // -----------------------------------------------------------------------------
 
-using System.Text.Json.Serialization;
-
 namespace NoFrixion.MoneyMoov.Enums;
 
 [Flags]
-[JsonConverter(typeof(JsonStringEnumConverter))]
 public enum OpenBankingOperationTypeEnum
 {
     /// <summary>

--- a/src/NoFrixion.MoneyMoov/Enums/PartialPaymentMethodsEnum.cs
+++ b/src/NoFrixion.MoneyMoov/Enums/PartialPaymentMethodsEnum.cs
@@ -14,11 +14,8 @@
 // MIT.
 //-----------------------------------------------------------------------------
 
-using System.Text.Json.Serialization;
-
 namespace NoFrixion.MoneyMoov;
 
-[JsonConverter(typeof(JsonStringEnumConverter))]
 public enum PartialPaymentMethodsEnum
 {
     /// <summary>

--- a/src/NoFrixion.MoneyMoov/Enums/PartialPaymentMethodsEnum.cs
+++ b/src/NoFrixion.MoneyMoov/Enums/PartialPaymentMethodsEnum.cs
@@ -14,8 +14,11 @@
 // MIT.
 //-----------------------------------------------------------------------------
 
+using System.Text.Json.Serialization;
+
 namespace NoFrixion.MoneyMoov;
 
+[JsonConverter(typeof(JsonStringEnumConverter))]
 public enum PartialPaymentMethodsEnum
 {
     /// <summary>

--- a/src/NoFrixion.MoneyMoov/Enums/PaymentMethodTypeEnum.cs
+++ b/src/NoFrixion.MoneyMoov/Enums/PaymentMethodTypeEnum.cs
@@ -12,12 +12,9 @@
 //  MIT.
 // -----------------------------------------------------------------------------
 
-using System.Text.Json.Serialization;
-
 namespace NoFrixion.MoneyMoov;
 
 [Flags]
-[JsonConverter(typeof(JsonStringEnumConverter))]
 public enum PaymentMethodTypeEnum
 {
     /// <summary>

--- a/src/NoFrixion.MoneyMoov/Enums/PaymentMethodTypeEnum.cs
+++ b/src/NoFrixion.MoneyMoov/Enums/PaymentMethodTypeEnum.cs
@@ -12,9 +12,12 @@
 //  MIT.
 // -----------------------------------------------------------------------------
 
+using System.Text.Json.Serialization;
+
 namespace NoFrixion.MoneyMoov;
 
 [Flags]
+[JsonConverter(typeof(JsonStringEnumConverter))]
 public enum PaymentMethodTypeEnum
 {
     /// <summary>

--- a/src/NoFrixion.MoneyMoov/Enums/PaymentProcessorsEnum.cs
+++ b/src/NoFrixion.MoneyMoov/Enums/PaymentProcessorsEnum.cs
@@ -14,14 +14,11 @@
 // MIT.
 //-----------------------------------------------------------------------------
 
-using System.Text.Json.Serialization;
-
 namespace NoFrixion.MoneyMoov;
 
 /// <summary>
 /// Lists the supported card and PIS processors.
 /// </summary>
-[JsonConverter(typeof(JsonStringEnumConverter))]
 public enum PaymentProcessorsEnum
 {
     /// <summary>

--- a/src/NoFrixion.MoneyMoov/Enums/PaymentProcessorsEnum.cs
+++ b/src/NoFrixion.MoneyMoov/Enums/PaymentProcessorsEnum.cs
@@ -14,11 +14,14 @@
 // MIT.
 //-----------------------------------------------------------------------------
 
+using System.Text.Json.Serialization;
+
 namespace NoFrixion.MoneyMoov;
 
 /// <summary>
 /// Lists the supported card and PIS processors.
 /// </summary>
+[JsonConverter(typeof(JsonStringEnumConverter))]
 public enum PaymentProcessorsEnum
 {
     /// <summary>

--- a/src/NoFrixion.MoneyMoov/Enums/PaymentRequestEventTypesEnum.cs
+++ b/src/NoFrixion.MoneyMoov/Enums/PaymentRequestEventTypesEnum.cs
@@ -15,11 +15,8 @@
 // MIT.
 // -----------------------------------------------------------------------------
 
-using System.Text.Json.Serialization;
-
 namespace NoFrixion.MoneyMoov;
 
-[JsonConverter(typeof(JsonStringEnumConverter))]
 public enum PaymentRequestEventTypesEnum
 {
     /// <summary>

--- a/src/NoFrixion.MoneyMoov/Enums/PaymentRequestEventTypesEnum.cs
+++ b/src/NoFrixion.MoneyMoov/Enums/PaymentRequestEventTypesEnum.cs
@@ -15,8 +15,11 @@
 // MIT.
 // -----------------------------------------------------------------------------
 
+using System.Text.Json.Serialization;
+
 namespace NoFrixion.MoneyMoov;
 
+[JsonConverter(typeof(JsonStringEnumConverter))]
 public enum PaymentRequestEventTypesEnum
 {
     /// <summary>

--- a/src/NoFrixion.MoneyMoov/Enums/PaymentRequestStatusFilterEnum.cs
+++ b/src/NoFrixion.MoneyMoov/Enums/PaymentRequestStatusFilterEnum.cs
@@ -12,11 +12,8 @@
 //  License: MIT
 // -----------------------------------------------------------------------------
 
-using System.Text.Json.Serialization;
-
 namespace NoFrixion.MoneyMoov;
 
-[JsonConverter(typeof(JsonStringEnumConverter))]
 public enum PaymentRequestStatusFilterEnum
 {
     /// <summary>

--- a/src/NoFrixion.MoneyMoov/Enums/PaymentRequestStatusFilterEnum.cs
+++ b/src/NoFrixion.MoneyMoov/Enums/PaymentRequestStatusFilterEnum.cs
@@ -12,8 +12,11 @@
 //  License: MIT
 // -----------------------------------------------------------------------------
 
+using System.Text.Json.Serialization;
+
 namespace NoFrixion.MoneyMoov;
 
+[JsonConverter(typeof(JsonStringEnumConverter))]
 public enum PaymentRequestStatusFilterEnum
 {
     /// <summary>

--- a/src/NoFrixion.MoneyMoov/Enums/PaymentResponseType.cs
+++ b/src/NoFrixion.MoneyMoov/Enums/PaymentResponseType.cs
@@ -14,8 +14,11 @@
 //  MIT.
 // -----------------------------------------------------------------------------
 
+using System.Text.Json.Serialization;
+
 namespace NoFrixion.MoneyMoov;
 
+[JsonConverter(typeof(JsonStringEnumConverter))]
 public enum PaymentResponseType
 {
     /// <summary>

--- a/src/NoFrixion.MoneyMoov/Enums/PaymentResponseType.cs
+++ b/src/NoFrixion.MoneyMoov/Enums/PaymentResponseType.cs
@@ -14,11 +14,8 @@
 //  MIT.
 // -----------------------------------------------------------------------------
 
-using System.Text.Json.Serialization;
-
 namespace NoFrixion.MoneyMoov;
 
-[JsonConverter(typeof(JsonStringEnumConverter))]
 public enum PaymentResponseType
 {
     /// <summary>

--- a/src/NoFrixion.MoneyMoov/Enums/PaymentResultEnum.cs
+++ b/src/NoFrixion.MoneyMoov/Enums/PaymentResultEnum.cs
@@ -13,11 +13,8 @@
 //  MIT.
 // -----------------------------------------------------------------------------
 
-using System.Text.Json.Serialization;
-
 namespace NoFrixion.MoneyMoov;
 
-[JsonConverter(typeof(JsonStringEnumConverter))]
 public enum PaymentResultEnum
 {
     /// <summary>

--- a/src/NoFrixion.MoneyMoov/Enums/PaymentResultEnum.cs
+++ b/src/NoFrixion.MoneyMoov/Enums/PaymentResultEnum.cs
@@ -13,8 +13,11 @@
 //  MIT.
 // -----------------------------------------------------------------------------
 
+using System.Text.Json.Serialization;
+
 namespace NoFrixion.MoneyMoov;
 
+[JsonConverter(typeof(JsonStringEnumConverter))]
 public enum PaymentResultEnum
 {
     /// <summary>

--- a/src/NoFrixion.MoneyMoov/Enums/PayoutEventTypesEnum.cs
+++ b/src/NoFrixion.MoneyMoov/Enums/PayoutEventTypesEnum.cs
@@ -14,11 +14,8 @@
 // MIT.
 // -----------------------------------------------------------------------------
 
-using System.Text.Json.Serialization;
-
 namespace NoFrixion.MoneyMoov;
 
-[JsonConverter(typeof(JsonStringEnumConverter))]
 public enum PayoutEventTypesEnum
 {
     /// <summary>

--- a/src/NoFrixion.MoneyMoov/Enums/PayoutEventTypesEnum.cs
+++ b/src/NoFrixion.MoneyMoov/Enums/PayoutEventTypesEnum.cs
@@ -14,83 +14,85 @@
 // MIT.
 // -----------------------------------------------------------------------------
 
-namespace NoFrixion.MoneyMoov
+using System.Text.Json.Serialization;
+
+namespace NoFrixion.MoneyMoov;
+
+[JsonConverter(typeof(JsonStringEnumConverter))]
+public enum PayoutEventTypesEnum
 {
-    public enum PayoutEventTypesEnum
-    {
-        /// <summary>
-        /// Something went wrong and the event type is unknown.
-        /// </summary>
-        Unknown = 0,
+    /// <summary>
+    /// Something went wrong and the event type is unknown.
+    /// </summary>
+    Unknown = 0,
 
-        /// <summary>
-        /// A payout was authorised by an approver.
-        /// </summary>
-        Authorise = 1,
+    /// <summary>
+    /// A payout was authorised by an approver.
+    /// </summary>
+    Authorise = 1,
 
-        /// <summary>
-        /// A payout was initiated with the supplier. 
-        /// </summary>
-        Initiate = 2,
+    /// <summary>
+    /// A payout was initiated with the supplier. 
+    /// </summary>
+    Initiate = 2,
 
-        /// <summary>
-        /// A payout was initiated. A webhook is sent out when the status of the payment changes.
-        /// </summary>
-        Webhook = 3,
+    /// <summary>
+    /// A payout was initiated. A webhook is sent out when the status of the payment changes.
+    /// </summary>
+    Webhook = 3,
 
-        /// <summary>
-        /// A payout was successful and verified through supplier transaction. 
-        /// </summary>
-        Settle = 4,
+    /// <summary>
+    /// A payout was successful and verified through supplier transaction. 
+    /// </summary>
+    Settle = 4,
 
-        /// <summary>
-        /// A payout was initiated but the funds failed to settle.
-        /// </summary>
-        Failure = 5,
-        
-        /// <summary>
-        /// A payout was created.
-        /// </summary>
-        Created = 6,
-        
-        /// <summary>
-        /// A payout was queued.
-        /// </summary>
-        Queued = 7,
-        
-        /// <summary>
-        /// A payout was scheduled.
-        /// </summary>
-        Scheduled = 8,
-        
-        /// <summary>
-        /// A payout's associated beneficiary was updated.
-        /// </summary>
-        BeneficiaryUpdated = 9,
-        
-        /// <summary>
-        /// A payout's associated beneficiary was disabled.
-        /// </summary>
-        BeneficiaryDisabled = 10,
-        
-        /// <summary>
-        /// A payout was edited.
-        /// </summary>
-        Edited = 11,
-        
-        /// <summary>
-        /// A payout was rejected by an approver.
-        /// </summary>
-        RejectedApproval = 12,
+    /// <summary>
+    /// A payout was initiated but the funds failed to settle.
+    /// </summary>
+    Failure = 5,
+    
+    /// <summary>
+    /// A payout was created.
+    /// </summary>
+    Created = 6,
+    
+    /// <summary>
+    /// A payout was queued.
+    /// </summary>
+    Queued = 7,
+    
+    /// <summary>
+    /// A payout was scheduled.
+    /// </summary>
+    Scheduled = 8,
+    
+    /// <summary>
+    /// A payout's associated beneficiary was updated.
+    /// </summary>
+    BeneficiaryUpdated = 9,
+    
+    /// <summary>
+    /// A payout's associated beneficiary was disabled.
+    /// </summary>
+    BeneficiaryDisabled = 10,
+    
+    /// <summary>
+    /// A payout was edited.
+    /// </summary>
+    Edited = 11,
+    
+    /// <summary>
+    /// A payout was rejected by an approver.
+    /// </summary>
+    RejectedApproval = 12,
 
-        /// <summary>
-        /// The payout has been authorised due to a submission from a trusted source.
-        /// </summary>
-        TrustedAuthorise = 13,
-        
-        /// <summary>
-        /// The payout has been signed.
-        /// </summary>
-        Signed = 14
-    }
+    /// <summary>
+    /// The payout has been authorised due to a submission from a trusted source.
+    /// </summary>
+    TrustedAuthorise = 13,
+    
+    /// <summary>
+    /// The payout has been signed.
+    /// </summary>
+    Signed = 14
 }

--- a/src/NoFrixion.MoneyMoov/Enums/PayoutStatus.cs
+++ b/src/NoFrixion.MoneyMoov/Enums/PayoutStatus.cs
@@ -14,14 +14,12 @@
 // -----------------------------------------------------------------------------
 
 using System.Runtime.Serialization;
-using System.Text.Json.Serialization;
 
 namespace NoFrixion.MoneyMoov;
 
 /// <summary>
 /// The status of payout.
 /// </summary>
-[JsonConverter(typeof(JsonStringEnumConverter))]
 public enum PayoutStatus
 {
     UNKNOWN = 0,

--- a/src/NoFrixion.MoneyMoov/Enums/PayoutStatus.cs
+++ b/src/NoFrixion.MoneyMoov/Enums/PayoutStatus.cs
@@ -14,15 +14,14 @@
 // -----------------------------------------------------------------------------
 
 using System.Runtime.Serialization;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Converters;
+using System.Text.Json.Serialization;
 
 namespace NoFrixion.MoneyMoov;
 
 /// <summary>
 /// The status of payout.
 /// </summary>
-[JsonConverter(typeof(StringEnumConverter))]
+[JsonConverter(typeof(JsonStringEnumConverter))]
 public enum PayoutStatus
 {
     UNKNOWN = 0,

--- a/src/NoFrixion.MoneyMoov/Enums/PayrunEventTypeEnum.cs
+++ b/src/NoFrixion.MoneyMoov/Enums/PayrunEventTypeEnum.cs
@@ -14,11 +14,8 @@
 //   Proprietary NoFrixion.
 //  -----------------------------------------------------------------------------
 
-using System.Text.Json.Serialization;
-
 namespace NoFrixion.MoneyMoov.Enums;
 
-[JsonConverter(typeof(JsonStringEnumConverter))]
 public enum PayrunEventTypeEnum
 {
     None = 0,

--- a/src/NoFrixion.MoneyMoov/Enums/PayrunEventTypeEnum.cs
+++ b/src/NoFrixion.MoneyMoov/Enums/PayrunEventTypeEnum.cs
@@ -14,8 +14,11 @@
 //   Proprietary NoFrixion.
 //  -----------------------------------------------------------------------------
 
+using System.Text.Json.Serialization;
+
 namespace NoFrixion.MoneyMoov.Enums;
 
+[JsonConverter(typeof(JsonStringEnumConverter))]
 public enum PayrunEventTypeEnum
 {
     None = 0,

--- a/src/NoFrixion.MoneyMoov/Enums/PayrunStatus.cs
+++ b/src/NoFrixion.MoneyMoov/Enums/PayrunStatus.cs
@@ -14,11 +14,8 @@
 //   Proprietary NoFrixion.
 //  -----------------------------------------------------------------------------
 
-using System.Text.Json.Serialization;
-
 namespace NoFrixion.MoneyMoov.Enums;
 
-[JsonConverter(typeof(JsonStringEnumConverter))]
 public enum PayrunStatus
 {
     None = 0,

--- a/src/NoFrixion.MoneyMoov/Enums/PayrunStatus.cs
+++ b/src/NoFrixion.MoneyMoov/Enums/PayrunStatus.cs
@@ -14,8 +14,11 @@
 //   Proprietary NoFrixion.
 //  -----------------------------------------------------------------------------
 
+using System.Text.Json.Serialization;
+
 namespace NoFrixion.MoneyMoov.Enums;
 
+[JsonConverter(typeof(JsonStringEnumConverter))]
 public enum PayrunStatus
 {
     None = 0,

--- a/src/NoFrixion.MoneyMoov/Enums/ReportStatusTypesEnum.cs
+++ b/src/NoFrixion.MoneyMoov/Enums/ReportStatusTypesEnum.cs
@@ -13,11 +13,8 @@
 // Proprietary NoFrixion.
 //-----------------------------------------------------------------------------
 
-using System.Text.Json.Serialization;
-
 namespace NoFrixion.MoneyMoov;
 
-[JsonConverter(typeof(JsonStringEnumConverter))]
 public enum ReportStatusTypesEnum
 {
     None = 0,

--- a/src/NoFrixion.MoneyMoov/Enums/ReportStatusTypesEnum.cs
+++ b/src/NoFrixion.MoneyMoov/Enums/ReportStatusTypesEnum.cs
@@ -13,8 +13,11 @@
 // Proprietary NoFrixion.
 //-----------------------------------------------------------------------------
 
+using System.Text.Json.Serialization;
+
 namespace NoFrixion.MoneyMoov;
 
+[JsonConverter(typeof(JsonStringEnumConverter))]
 public enum ReportStatusTypesEnum
 {
     None = 0,

--- a/src/NoFrixion.MoneyMoov/Enums/ReportTypesEnum.cs
+++ b/src/NoFrixion.MoneyMoov/Enums/ReportTypesEnum.cs
@@ -13,11 +13,8 @@
 // Proprietary NoFrixion.
 //-----------------------------------------------------------------------------
 
-using System.Text.Json.Serialization;
-
 namespace NoFrixion.MoneyMoov;
 
-[JsonConverter(typeof(JsonStringEnumConverter))]
 public enum ReportTypesEnum
 {
     Unknown = 0,

--- a/src/NoFrixion.MoneyMoov/Enums/ReportTypesEnum.cs
+++ b/src/NoFrixion.MoneyMoov/Enums/ReportTypesEnum.cs
@@ -13,8 +13,11 @@
 // Proprietary NoFrixion.
 //-----------------------------------------------------------------------------
 
+using System.Text.Json.Serialization;
+
 namespace NoFrixion.MoneyMoov;
 
+[JsonConverter(typeof(JsonStringEnumConverter))]
 public enum ReportTypesEnum
 {
     Unknown = 0,

--- a/src/NoFrixion.MoneyMoov/Enums/RuleActionsEnum.cs
+++ b/src/NoFrixion.MoneyMoov/Enums/RuleActionsEnum.cs
@@ -14,12 +14,11 @@
 // MIT.
 //-----------------------------------------------------------------------------
 
-using Newtonsoft.Json;
-using Newtonsoft.Json.Converters;
+using System.Text.Json.Serialization;
 
 namespace NoFrixion.MoneyMoov;
 
-[JsonConverter(typeof(StringEnumConverter))]
+[JsonConverter(typeof(JsonStringEnumConverter))]
 public enum RuleActionsEnum
 {
     IsAlive,

--- a/src/NoFrixion.MoneyMoov/Enums/RuleActionsEnum.cs
+++ b/src/NoFrixion.MoneyMoov/Enums/RuleActionsEnum.cs
@@ -14,11 +14,8 @@
 // MIT.
 //-----------------------------------------------------------------------------
 
-using System.Text.Json.Serialization;
-
 namespace NoFrixion.MoneyMoov;
 
-[JsonConverter(typeof(JsonStringEnumConverter))]
 public enum RuleActionsEnum
 {
     IsAlive,

--- a/src/NoFrixion.MoneyMoov/Enums/RuleEventTypesEnum.cs
+++ b/src/NoFrixion.MoneyMoov/Enums/RuleEventTypesEnum.cs
@@ -13,12 +13,11 @@
 // MIT.
 //-----------------------------------------------------------------------------
 
-using Newtonsoft.Json;
-using Newtonsoft.Json.Converters;
+using System.Text.Json.Serialization;
 
 namespace NoFrixion.MoneyMoov;
 
-[JsonConverter(typeof(StringEnumConverter))]
+[JsonConverter(typeof(JsonStringEnumConverter))]
 public enum RuleEventTypesEnum
 {
     None,

--- a/src/NoFrixion.MoneyMoov/Enums/RuleEventTypesEnum.cs
+++ b/src/NoFrixion.MoneyMoov/Enums/RuleEventTypesEnum.cs
@@ -13,11 +13,8 @@
 // MIT.
 //-----------------------------------------------------------------------------
 
-using System.Text.Json.Serialization;
-
 namespace NoFrixion.MoneyMoov;
 
-[JsonConverter(typeof(JsonStringEnumConverter))]
 public enum RuleEventTypesEnum
 {
     None,

--- a/src/NoFrixion.MoneyMoov/Enums/RuleStatusEnum.cs
+++ b/src/NoFrixion.MoneyMoov/Enums/RuleStatusEnum.cs
@@ -13,12 +13,11 @@
 // MIT.
 //-----------------------------------------------------------------------------
 
-using Newtonsoft.Json;
-using Newtonsoft.Json.Converters;
+using System.Text.Json.Serialization;
 
 namespace NoFrixion.MoneyMoov;
 
-[JsonConverter(typeof(StringEnumConverter))]
+[JsonConverter(typeof(JsonStringEnumConverter))]
 public enum RuleStatusEnum
 {
     PendingApproval,

--- a/src/NoFrixion.MoneyMoov/Enums/RuleStatusEnum.cs
+++ b/src/NoFrixion.MoneyMoov/Enums/RuleStatusEnum.cs
@@ -13,11 +13,8 @@
 // MIT.
 //-----------------------------------------------------------------------------
 
-using System.Text.Json.Serialization;
-
 namespace NoFrixion.MoneyMoov;
 
-[JsonConverter(typeof(JsonStringEnumConverter))]
 public enum RuleStatusEnum
 {
     PendingApproval,

--- a/src/NoFrixion.MoneyMoov/Enums/StatementGenerationStatusEnum.cs
+++ b/src/NoFrixion.MoneyMoov/Enums/StatementGenerationStatusEnum.cs
@@ -13,11 +13,8 @@
 //  Proprietary NoFrixion.
 // -----------------------------------------------------------------------------
 
-using System.Text.Json.Serialization;
-
 namespace NoFrixion.MoneyMoov.Enums;
 
-[JsonConverter(typeof(JsonStringEnumConverter))]
 public enum StatementGenerationStatusEnum
 {
     Unknown,

--- a/src/NoFrixion.MoneyMoov/Enums/StatementGenerationStatusEnum.cs
+++ b/src/NoFrixion.MoneyMoov/Enums/StatementGenerationStatusEnum.cs
@@ -13,8 +13,11 @@
 //  Proprietary NoFrixion.
 // -----------------------------------------------------------------------------
 
+using System.Text.Json.Serialization;
+
 namespace NoFrixion.MoneyMoov.Enums;
 
+[JsonConverter(typeof(JsonStringEnumConverter))]
 public enum StatementGenerationStatusEnum
 {
     Unknown,

--- a/src/NoFrixion.MoneyMoov/Enums/TimeFrequencyEnum.cs
+++ b/src/NoFrixion.MoneyMoov/Enums/TimeFrequencyEnum.cs
@@ -13,8 +13,11 @@
 //  Proprietary NoFrixion.
 // -----------------------------------------------------------------------------
 
+using System.Text.Json.Serialization;
+
 namespace NoFrixion.MoneyMoov.Enums;
 
+[JsonConverter(typeof(JsonStringEnumConverter))]
 public enum TimeFrequencyEnum
 {
     None,

--- a/src/NoFrixion.MoneyMoov/Enums/TimeFrequencyEnum.cs
+++ b/src/NoFrixion.MoneyMoov/Enums/TimeFrequencyEnum.cs
@@ -13,11 +13,8 @@
 //  Proprietary NoFrixion.
 // -----------------------------------------------------------------------------
 
-using System.Text.Json.Serialization;
-
 namespace NoFrixion.MoneyMoov.Enums;
 
-[JsonConverter(typeof(JsonStringEnumConverter))]
 public enum TimeFrequencyEnum
 {
     None,

--- a/src/NoFrixion.MoneyMoov/Enums/TransactionFilterEum.cs
+++ b/src/NoFrixion.MoneyMoov/Enums/TransactionFilterEum.cs
@@ -14,8 +14,11 @@
 // Proprietary NoFrixion.
 //-----------------------------------------------------------------------------
 
+using System.Text.Json.Serialization;
+
 namespace NoFrixion.MoneyMoov;
 
+[JsonConverter(typeof(JsonStringEnumConverter))]
 public enum TransactionCreditTypesEnum
 {
     /// <summary>

--- a/src/NoFrixion.MoneyMoov/Enums/TransactionFilterEum.cs
+++ b/src/NoFrixion.MoneyMoov/Enums/TransactionFilterEum.cs
@@ -14,11 +14,8 @@
 // Proprietary NoFrixion.
 //-----------------------------------------------------------------------------
 
-using System.Text.Json.Serialization;
-
 namespace NoFrixion.MoneyMoov;
 
-[JsonConverter(typeof(JsonStringEnumConverter))]
 public enum TransactionCreditTypesEnum
 {
     /// <summary>

--- a/src/NoFrixion.MoneyMoov/Enums/TransactionStatementFormat.cs
+++ b/src/NoFrixion.MoneyMoov/Enums/TransactionStatementFormat.cs
@@ -13,11 +13,8 @@
 //  Proprietary NoFrixion.
 // -----------------------------------------------------------------------------
 
-using System.Text.Json.Serialization;
-
 namespace NoFrixion.MoneyMoov.Enums;
 
-[JsonConverter(typeof(JsonStringEnumConverter))]
 public enum TransactionStatementFormat
 {
     Pdf,

--- a/src/NoFrixion.MoneyMoov/Enums/TransactionStatementFormat.cs
+++ b/src/NoFrixion.MoneyMoov/Enums/TransactionStatementFormat.cs
@@ -13,8 +13,11 @@
 //  Proprietary NoFrixion.
 // -----------------------------------------------------------------------------
 
+using System.Text.Json.Serialization;
+
 namespace NoFrixion.MoneyMoov.Enums;
 
+[JsonConverter(typeof(JsonStringEnumConverter))]
 public enum TransactionStatementFormat
 {
     Pdf,

--- a/src/NoFrixion.MoneyMoov/Enums/TransactionTypesEnum.cs
+++ b/src/NoFrixion.MoneyMoov/Enums/TransactionTypesEnum.cs
@@ -15,11 +15,9 @@
 // -----------------------------------------------------------------------------
 
 using System.ComponentModel.DataAnnotations;
-using System.Text.Json.Serialization;
 
 namespace NoFrixion.MoneyMoov;
 
-[JsonConverter(typeof(JsonStringEnumConverter))]
 public enum TransactionTypesEnum
 {
     /// <summary>

--- a/src/NoFrixion.MoneyMoov/Enums/TransactionTypesEnum.cs
+++ b/src/NoFrixion.MoneyMoov/Enums/TransactionTypesEnum.cs
@@ -14,13 +14,12 @@
 //  MIT.
 // -----------------------------------------------------------------------------
 
-using Newtonsoft.Json;
-using Newtonsoft.Json.Converters;
 using System.ComponentModel.DataAnnotations;
+using System.Text.Json.Serialization;
 
 namespace NoFrixion.MoneyMoov;
 
-[JsonConverter(typeof(StringEnumConverter))]
+[JsonConverter(typeof(JsonStringEnumConverter))]
 public enum TransactionTypesEnum
 {
     /// <summary>

--- a/src/NoFrixion.MoneyMoov/Enums/UserInviteStatusEnum.cs
+++ b/src/NoFrixion.MoneyMoov/Enums/UserInviteStatusEnum.cs
@@ -12,8 +12,11 @@
 // MIT.
 // -----------------------------------------------------------------------------
 
+using System.Text.Json.Serialization;
+
 namespace NoFrixion.MoneyMoov;
 
+[JsonConverter(typeof(JsonStringEnumConverter))]
 public enum UserInviteStatusEnum
 {
     /// <summary>

--- a/src/NoFrixion.MoneyMoov/Enums/UserInviteStatusEnum.cs
+++ b/src/NoFrixion.MoneyMoov/Enums/UserInviteStatusEnum.cs
@@ -12,11 +12,8 @@
 // MIT.
 // -----------------------------------------------------------------------------
 
-using System.Text.Json.Serialization;
-
 namespace NoFrixion.MoneyMoov;
 
-[JsonConverter(typeof(JsonStringEnumConverter))]
 public enum UserInviteStatusEnum
 {
     /// <summary>

--- a/src/NoFrixion.MoneyMoov/Enums/UserRolesEnum.cs
+++ b/src/NoFrixion.MoneyMoov/Enums/UserRolesEnum.cs
@@ -15,11 +15,8 @@
 // MIT.
 //-----------------------------------------------------------------------------
 
-using System.Text.Json.Serialization;
-
 namespace NoFrixion.MoneyMoov;
 
-[JsonConverter(typeof(JsonStringEnumConverter))]
 public enum UserRolesEnum : int
 {
     /// <summary>

--- a/src/NoFrixion.MoneyMoov/Enums/UserRolesEnum.cs
+++ b/src/NoFrixion.MoneyMoov/Enums/UserRolesEnum.cs
@@ -15,8 +15,11 @@
 // MIT.
 //-----------------------------------------------------------------------------
 
+using System.Text.Json.Serialization;
+
 namespace NoFrixion.MoneyMoov;
 
+[JsonConverter(typeof(JsonStringEnumConverter))]
 public enum UserRolesEnum : int
 {
     /// <summary>

--- a/src/NoFrixion.MoneyMoov/Enums/WalletsEnum.cs
+++ b/src/NoFrixion.MoneyMoov/Enums/WalletsEnum.cs
@@ -13,8 +13,11 @@
 //  Proprietary NoFrixion.
 // -----------------------------------------------------------------------------
 
+using System.Text.Json.Serialization;
+
 namespace NoFrixion.MoneyMoov;
 
+[JsonConverter(typeof(JsonStringEnumConverter))]
 public enum WalletsEnum
 {
     ApplePay,

--- a/src/NoFrixion.MoneyMoov/Enums/WalletsEnum.cs
+++ b/src/NoFrixion.MoneyMoov/Enums/WalletsEnum.cs
@@ -13,11 +13,8 @@
 //  Proprietary NoFrixion.
 // -----------------------------------------------------------------------------
 
-using System.Text.Json.Serialization;
-
 namespace NoFrixion.MoneyMoov;
 
-[JsonConverter(typeof(JsonStringEnumConverter))]
 public enum WalletsEnum
 {
     ApplePay,

--- a/src/NoFrixion.MoneyMoov/Enums/WebhookActionsEnum.cs
+++ b/src/NoFrixion.MoneyMoov/Enums/WebhookActionsEnum.cs
@@ -14,12 +14,11 @@
 // MIT.
 //-----------------------------------------------------------------------------
 
-using Newtonsoft.Json;
-using Newtonsoft.Json.Converters;
+using System.Text.Json.Serialization;
 
 namespace NoFrixion.MoneyMoov;
 
-[JsonConverter(typeof(StringEnumConverter))]
+[JsonConverter(typeof(JsonStringEnumConverter))]
 public enum WebhookActionsEnum
 {
     Created,

--- a/src/NoFrixion.MoneyMoov/Enums/WebhookActionsEnum.cs
+++ b/src/NoFrixion.MoneyMoov/Enums/WebhookActionsEnum.cs
@@ -14,11 +14,8 @@
 // MIT.
 //-----------------------------------------------------------------------------
 
-using System.Text.Json.Serialization;
-
 namespace NoFrixion.MoneyMoov;
 
-[JsonConverter(typeof(JsonStringEnumConverter))]
 public enum WebhookActionsEnum
 {
     Created,

--- a/src/NoFrixion.MoneyMoov/Enums/WebhookResourceTypesEnum.cs
+++ b/src/NoFrixion.MoneyMoov/Enums/WebhookResourceTypesEnum.cs
@@ -14,12 +14,9 @@
 // MIT.
 // -----------------------------------------------------------------------------
 
-using System.Text.Json.Serialization;
-
 namespace NoFrixion.MoneyMoov;
 
 [Flags]
-[JsonConverter(typeof(JsonStringEnumConverter))]
 public enum WebhookResourceTypesEnum
 {
     None = 0,

--- a/src/NoFrixion.MoneyMoov/Enums/WebhookResourceTypesEnum.cs
+++ b/src/NoFrixion.MoneyMoov/Enums/WebhookResourceTypesEnum.cs
@@ -14,13 +14,12 @@
 // MIT.
 // -----------------------------------------------------------------------------
 
-using Newtonsoft.Json;
-using Newtonsoft.Json.Converters;
+using System.Text.Json.Serialization;
 
 namespace NoFrixion.MoneyMoov;
 
 [Flags]
-[JsonConverter(typeof(StringEnumConverter))]
+[JsonConverter(typeof(JsonStringEnumConverter))]
 public enum WebhookResourceTypesEnum
 {
     None = 0,

--- a/src/NoFrixion.MoneyMoov/Extensions/JsonExtensions.cs
+++ b/src/NoFrixion.MoneyMoov/Extensions/JsonExtensions.cs
@@ -1,7 +1,8 @@
 ﻿//-----------------------------------------------------------------------------
 // Filename: JsonExtensions.cs
 //
-// Description: Extension methods for the common JSON operations.
+// Description: Extension methods for the common JSON operations with option
+// to use either System.Text.Json or Newtonsoft.Json.
 //
 // Author(s):
 // Aaron Clauson
@@ -13,33 +14,51 @@
 // MIT.
 //-----------------------------------------------------------------------------
 
-using System.Text.Json;
 using System.Net.Http.Json;
 using Ardalis.GuardClauses;
+using Newtonsoft.Json;
 
 namespace NoFrixion.MoneyMoov;
 
 public static class JsonExtensions
 {
     public static string ToJsonFlat<T>(this T obj)
-    {
-        return JsonSerializer.Serialize(obj, MoneyMoovJson.GetSystemTextSerialiserOptions());
-    }
+        => obj.ToJsonFlatNewtonsoft();
 
     public static string ToJsonFormatted<T>(this T obj)
-    {
-        return JsonSerializer.Serialize(obj, MoneyMoovJson.GetSystemTextSerialiserOptions(true));
-    }
+        => obj.ToJsonFormattedNewtonsoft();
 
     public static T? FromJson<T>(this string json)
-    {
-        Guard.Against.NullOrWhiteSpace(json, nameof(json));
-
-        return JsonSerializer.Deserialize<T>(json, MoneyMoovJson.GetSystemTextSerialiserOptions());
-    }
+        => json.FromJsonNewtonsoft<T>();
 
     public static JsonContent ToJsonContent<T>(this T obj)
     {
         return JsonContent.Create(obj, options: MoneyMoovJson.GetSystemTextSerialiserOptions());
+    }
+
+    private static string ToJsonFlatSystemText<T>(this T obj)
+        => System.Text.Json.JsonSerializer.Serialize(obj, MoneyMoovJson.GetSystemTextSerialiserOptions());
+
+    private static string ToJsonFormattedSystemText<T>(this T obj)
+        => System.Text.Json.JsonSerializer.Serialize(obj, MoneyMoovJson.GetSystemTextSerialiserOptions(true));
+
+    private static T? FromJsonSystemText<T>(this string json)
+    {
+        Guard.Against.NullOrWhiteSpace(json, nameof(json));
+
+        return System.Text.Json.JsonSerializer.Deserialize<T>(json, MoneyMoovJson.GetSystemTextSerialiserOptions());
+    }
+
+    private static string ToJsonFlatNewtonsoft<T>(this T obj)
+        => JsonConvert.SerializeObject(obj, MoneyMoovJson.GetNewtonsoftSerialiserSettings());
+
+    private static string ToJsonFormattedNewtonsoft<T>(this T obj)
+        => JsonConvert.SerializeObject(obj, MoneyMoovJson.GetNewtonsoftSerialiserSettings(true));
+
+    private static T? FromJsonNewtonsoft<T>(this string json)
+    {
+        Guard.Against.NullOrWhiteSpace(json, nameof(json));
+
+        return JsonConvert.DeserializeObject<T>(json, MoneyMoovJson.GetNewtonsoftSerialiserSettings());
     }
 }

--- a/src/NoFrixion.MoneyMoov/Extensions/JsonExtensions.cs
+++ b/src/NoFrixion.MoneyMoov/Extensions/JsonExtensions.cs
@@ -1,0 +1,33 @@
+﻿//-----------------------------------------------------------------------------
+// Filename: JsonExtensions.cs
+//
+// Description: Extension methods for the common JSON operations.
+//
+// Author(s):
+// Aaron Clauson
+// 
+// History:
+// 08 Jun 2024  Aaron Clauson   Created, Stillorgan Wood, Dublin, Ireland.
+//
+// License: 
+// Proprietary NoFrixion.
+//-----------------------------------------------------------------------------
+
+using System.Text.Json.Serialization;
+using System.Text.Json;
+
+namespace NoFrixion.MoneyMoov;
+
+public static class JsonExtensions
+{
+    private static readonly JsonSerializerOptions _serialiseOptions = new JsonSerializerOptions
+    {
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+        WriteIndented = true
+    };
+
+    public static string ToJsonFormatted<T>(this T obj)
+    {
+        return JsonSerializer.Serialize(obj, _serialiseOptions);
+    }
+}

--- a/src/NoFrixion.MoneyMoov/Extensions/JsonExtensions.cs
+++ b/src/NoFrixion.MoneyMoov/Extensions/JsonExtensions.cs
@@ -28,7 +28,10 @@ public static class JsonExtensions
         return new JsonSerializerOptions
         {
             PropertyNameCaseInsensitive = true,
-            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+
+            // Set the JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull) attribute on properties to ignore null values.
+            //DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull, 
+
             ReferenceHandler = ReferenceHandler.IgnoreCycles,
             PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
             WriteIndented = writeIndented,
@@ -36,6 +39,9 @@ public static class JsonExtensions
             {
                 // Allow enum values or member attribute values,e.g. [EnumMember(Value = "xxx")] to be deserialised from strings.
                 new JsonStringEnumMemberConverter(),
+
+                // Allows "true" and "false" strings to be deserialised to booleans.
+                new BooleanAsStringConverter(),
 
                 // Newtonsoft allows numeric values to be deserialised from strings.
                 // This is not the default behaviour in System.Text.Json so use a custom converter.

--- a/src/NoFrixion.MoneyMoov/Extensions/JsonExtensions.cs
+++ b/src/NoFrixion.MoneyMoov/Extensions/JsonExtensions.cs
@@ -15,19 +15,45 @@
 
 using System.Text.Json.Serialization;
 using System.Text.Json;
+using System.Net.Http.Json;
 
 namespace NoFrixion.MoneyMoov;
 
 public static class JsonExtensions
 {
-    private static readonly JsonSerializerOptions _serialiseOptions = new JsonSerializerOptions
+    public static readonly JsonSerializerOptions SerialiseOptions = new JsonSerializerOptions
     {
+        PropertyNameCaseInsensitive = true,
         DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
-        WriteIndented = true
+        ReferenceHandler = ReferenceHandler.IgnoreCycles,
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        Converters = { new JsonStringEnumConverter(JsonNamingPolicy.CamelCase) }
     };
 
     public static string ToJsonFormatted<T>(this T obj)
     {
-        return JsonSerializer.Serialize(obj, _serialiseOptions);
+        return JsonSerializer.Serialize(obj, SerialiseOptions);
+    }
+
+    public static T? FromJson<T>(this string json)
+    {
+        if (string.IsNullOrWhiteSpace(json))
+        {
+            return default;
+        }
+
+        try
+        {
+            return JsonSerializer.Deserialize<T>(json, SerialiseOptions);
+        }
+        catch (JsonException)
+        {
+            return default;
+        }
+    }
+
+    public static JsonContent ToJsonContent<T>(this T obj)
+    {
+        return JsonContent.Create(obj, options: SerialiseOptions);
     }
 }

--- a/src/NoFrixion.MoneyMoov/Extensions/JsonExtensions.cs
+++ b/src/NoFrixion.MoneyMoov/Extensions/JsonExtensions.cs
@@ -23,23 +23,23 @@ public static class JsonExtensions
 {
     public static string ToJsonFlat<T>(this T obj)
     {
-        return JsonSerializer.Serialize(obj, MoneyMoovJson.GetSerialiserOptions());
+        return JsonSerializer.Serialize(obj, MoneyMoovJson.GetSystemTextSerialiserOptions());
     }
 
     public static string ToJsonFormatted<T>(this T obj)
     {
-        return JsonSerializer.Serialize(obj, MoneyMoovJson.GetSerialiserOptions(true));
+        return JsonSerializer.Serialize(obj, MoneyMoovJson.GetSystemTextSerialiserOptions(true));
     }
 
     public static T? FromJson<T>(this string json)
     {
         Guard.Against.NullOrWhiteSpace(json, nameof(json));
 
-        return JsonSerializer.Deserialize<T>(json, MoneyMoovJson.GetSerialiserOptions());
+        return JsonSerializer.Deserialize<T>(json, MoneyMoovJson.GetSystemTextSerialiserOptions());
     }
 
     public static JsonContent ToJsonContent<T>(this T obj)
     {
-        return JsonContent.Create(obj, options: MoneyMoovJson.GetSerialiserOptions());
+        return JsonContent.Create(obj, options: MoneyMoovJson.GetSystemTextSerialiserOptions());
     }
 }

--- a/src/NoFrixion.MoneyMoov/Extensions/JsonExtensions.cs
+++ b/src/NoFrixion.MoneyMoov/Extensions/JsonExtensions.cs
@@ -10,69 +10,36 @@
 // 08 Jun 2024  Aaron Clauson   Created, Stillorgan Wood, Dublin, Ireland.
 //
 // License: 
-// Proprietary NoFrixion.
+// MIT.
 //-----------------------------------------------------------------------------
 
-using System.Text.Json.Serialization;
 using System.Text.Json;
 using System.Net.Http.Json;
 using Ardalis.GuardClauses;
-using NoFrixion.MoneyMoov.Json;
 
 namespace NoFrixion.MoneyMoov;
 
 public static class JsonExtensions
 {
-    public static JsonSerializerOptions GetSerialiserOptions(bool writeIndented = false)
-    {
-        return new JsonSerializerOptions
-        {
-            PropertyNameCaseInsensitive = true,
-
-            // Set the JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull) attribute on properties to ignore null values.
-            //DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull, 
-
-            ReferenceHandler = ReferenceHandler.IgnoreCycles,
-            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-            WriteIndented = writeIndented,
-            Converters =
-            {
-                // Allow enum values or member attribute values,e.g. [EnumMember(Value = "xxx")] to be deserialised from strings.
-                new JsonStringEnumMemberConverter(),
-
-                // Allows "true" and "false" strings to be deserialised to booleans.
-                new BooleanAsStringConverter(),
-
-                // Newtonsoft allows numeric values to be deserialised from strings.
-                // This is not the default behaviour in System.Text.Json so use a custom converter.
-                new NumericConverter<int>(),
-                new NumericConverter<long>(),
-                new NumericConverter<float>(),
-                new NumericConverter<double>(),
-                new NumericConverter<decimal>()
-            }
-        };
-    }
-
     public static string ToJsonFlat<T>(this T obj)
     {
-        return JsonSerializer.Serialize(obj, GetSerialiserOptions());
+        return JsonSerializer.Serialize(obj, MoneyMoovJson.GetSerialiserOptions());
     }
 
     public static string ToJsonFormatted<T>(this T obj)
     {
-        return JsonSerializer.Serialize(obj, GetSerialiserOptions(true));
+        return JsonSerializer.Serialize(obj, MoneyMoovJson.GetSerialiserOptions(true));
     }
 
     public static T? FromJson<T>(this string json)
     {
         Guard.Against.NullOrWhiteSpace(json, nameof(json));
 
-        return JsonSerializer.Deserialize<T>(json, GetSerialiserOptions());
+        return JsonSerializer.Deserialize<T>(json, MoneyMoovJson.GetSerialiserOptions());
     }
 
     public static JsonContent ToJsonContent<T>(this T obj)
     {
-        return JsonContent.Create(obj, options: GetSerialiserOptions());
+        return JsonContent.Create(obj, options: MoneyMoovJson.GetSerialiserOptions());
     }
 }

--- a/src/NoFrixion.MoneyMoov/Extensions/JsonExtensions.cs
+++ b/src/NoFrixion.MoneyMoov/Extensions/JsonExtensions.cs
@@ -16,44 +16,57 @@
 using System.Text.Json.Serialization;
 using System.Text.Json;
 using System.Net.Http.Json;
+using Ardalis.GuardClauses;
+using NoFrixion.MoneyMoov.Json;
 
 namespace NoFrixion.MoneyMoov;
 
 public static class JsonExtensions
 {
-    public static readonly JsonSerializerOptions SerialiseOptions = new JsonSerializerOptions
+    public static JsonSerializerOptions GetSerialiserOptions(bool writeIndented = false)
     {
-        PropertyNameCaseInsensitive = true,
-        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
-        ReferenceHandler = ReferenceHandler.IgnoreCycles,
-        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-        Converters = { new JsonStringEnumConverter(JsonNamingPolicy.CamelCase) }
-    };
+        return new JsonSerializerOptions
+        {
+            PropertyNameCaseInsensitive = true,
+            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+            ReferenceHandler = ReferenceHandler.IgnoreCycles,
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            WriteIndented = writeIndented,
+            Converters =
+            {
+                // Allow enum values or member attribute values,e.g. [EnumMember(Value = "xxx")] to be deserialised from strings.
+                new JsonStringEnumMemberConverter(),
+
+                // Newtonsoft allows numeric values to be deserialised from strings.
+                // This is not the default behaviour in System.Text.Json so use a custom converter.
+                new NumericConverter<int>(),
+                new NumericConverter<long>(),
+                new NumericConverter<float>(),
+                new NumericConverter<double>(),
+                new NumericConverter<decimal>()
+            }
+        };
+    }
+
+    public static string ToJsonFlat<T>(this T obj)
+    {
+        return JsonSerializer.Serialize(obj, GetSerialiserOptions());
+    }
 
     public static string ToJsonFormatted<T>(this T obj)
     {
-        return JsonSerializer.Serialize(obj, SerialiseOptions);
+        return JsonSerializer.Serialize(obj, GetSerialiserOptions(true));
     }
 
     public static T? FromJson<T>(this string json)
     {
-        if (string.IsNullOrWhiteSpace(json))
-        {
-            return default;
-        }
+        Guard.Against.NullOrWhiteSpace(json, nameof(json));
 
-        try
-        {
-            return JsonSerializer.Deserialize<T>(json, SerialiseOptions);
-        }
-        catch (JsonException)
-        {
-            return default;
-        }
+        return JsonSerializer.Deserialize<T>(json, GetSerialiserOptions());
     }
 
     public static JsonContent ToJsonContent<T>(this T obj)
     {
-        return JsonContent.Create(obj, options: SerialiseOptions);
+        return JsonContent.Create(obj, options: GetSerialiserOptions());
     }
 }

--- a/src/NoFrixion.MoneyMoov/JsonConverters/BooleanStringConverter.cs
+++ b/src/NoFrixion.MoneyMoov/JsonConverters/BooleanStringConverter.cs
@@ -10,7 +10,7 @@
 // 09 Jun 2024  Aaron Clauson   Created, Stillorgan Wood, Dublin, Ireland.
 //
 // License: 
-// Proprietary NoFrixion.
+// MIT.
 //-----------------------------------------------------------------------------
 
 using System.Text.Json.Serialization;

--- a/src/NoFrixion.MoneyMoov/JsonConverters/BooleanStringConverter.cs
+++ b/src/NoFrixion.MoneyMoov/JsonConverters/BooleanStringConverter.cs
@@ -44,6 +44,6 @@ public class BooleanAsStringConverter : JsonConverter<bool>
 
     public override void Write(Utf8JsonWriter writer, bool value, JsonSerializerOptions options)
     {
-        writer.WriteStringValue(value.ToString().ToLower());
+         writer.WriteBooleanValue(value);
     }
 }

--- a/src/NoFrixion.MoneyMoov/JsonConverters/BooleanStringConverter.cs
+++ b/src/NoFrixion.MoneyMoov/JsonConverters/BooleanStringConverter.cs
@@ -1,0 +1,49 @@
+﻿//-----------------------------------------------------------------------------
+// Filename: BooleanStringConverter.cs
+//
+// Description: Converter for deserialsing strings to booleans.
+//
+// Author(s):
+// Aaron Clauson
+// 
+// History:
+// 09 Jun 2024  Aaron Clauson   Created, Stillorgan Wood, Dublin, Ireland.
+//
+// License: 
+// Proprietary NoFrixion.
+//-----------------------------------------------------------------------------
+
+using System.Text.Json.Serialization;
+using System.Text.Json;
+
+namespace NoFrixion.MoneyMoov.Json;
+
+public class BooleanAsStringConverter : JsonConverter<bool>
+{
+    public override bool Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        if (reader.TokenType == JsonTokenType.String)
+        {
+            var stringValue = reader.GetString();
+            if (bool.TryParse(stringValue, out bool boolValue))
+            {
+                return boolValue;
+            }
+            throw new JsonException($"Unable to convert \"{stringValue}\" to boolean.");
+        }
+        else if (reader.TokenType == JsonTokenType.True)
+        {
+            return true;
+        }
+        else if (reader.TokenType == JsonTokenType.False)
+        {
+            return false;
+        }
+        throw new JsonException($"Unexpected token parsing boolean. Expected String, True, or False, got {reader.TokenType}.");
+    }
+
+    public override void Write(Utf8JsonWriter writer, bool value, JsonSerializerOptions options)
+    {
+        writer.WriteStringValue(value.ToString().ToLower());
+    }
+}

--- a/src/NoFrixion.MoneyMoov/JsonConverters/BooleanStringConverter.cs
+++ b/src/NoFrixion.MoneyMoov/JsonConverters/BooleanStringConverter.cs
@@ -1,7 +1,8 @@
 ﻿//-----------------------------------------------------------------------------
 // Filename: BooleanStringConverter.cs
 //
-// Description: Converter for deserialsing strings to booleans.
+// Description: Converter for deserialsing strings to booleans. This converter
+// is only required for System.Text.Json as Newtonsoft already supports this.
 //
 // Author(s):
 // Aaron Clauson

--- a/src/NoFrixion.MoneyMoov/JsonConverters/JsonStringEnumMemberConverter.cs
+++ b/src/NoFrixion.MoneyMoov/JsonConverters/JsonStringEnumMemberConverter.cs
@@ -1,0 +1,96 @@
+﻿//-----------------------------------------------------------------------------
+// Filename: JsonStringEnumMemberConverter.cs
+//
+// Description: Converter for deserialsing strings to enums. Allows both the enum
+// value and the member attribute to be used as the string value.
+//
+// Author(s):
+// Aaron Clauson
+// 
+// History:
+// 09 Jun 2024  Aaron Clauson   Created, Stillorgan Wood, Dublin, Ireland.
+//
+// License: 
+// Proprietary NoFrixion.
+//-----------------------------------------------------------------------------
+
+using System.Reflection;
+using System.Runtime.Serialization;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace NoFrixion.MoneyMoov.Json;
+
+public class JsonStringEnumMemberConverter : JsonConverterFactory
+{
+    public override bool CanConvert(Type typeToConvert)
+    {
+        return typeToConvert.IsEnum;
+    }
+
+    public override JsonConverter CreateConverter(Type typeToConvert, JsonSerializerOptions options)
+    {
+        var converterType = typeof(EnumMemberConverter<>).MakeGenericType(typeToConvert);
+        var converter = (JsonConverter?)Activator.CreateInstance(converterType);
+        if (converter == null)
+        {
+            throw new InvalidOperationException($"Unable to create converter for {typeToConvert}");
+        }
+        return converter;
+    }
+
+    private class EnumMemberConverter<T> : JsonConverter<T> where T : struct, Enum
+    {
+        public override T Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            if (reader.TokenType == JsonTokenType.String)
+            {
+                var enumText = reader.GetString();
+
+                // Check for EnumMember attribute values
+                foreach (var field in typeof(T).GetFields())
+                {
+                    if (field.GetCustomAttribute<EnumMemberAttribute>() is EnumMemberAttribute attribute)
+                    {
+                        if (string.Equals(attribute.Value, enumText, StringComparison.OrdinalIgnoreCase))
+                        {
+                            return (T)(field.GetValue(null) ?? default(T));
+                        }
+                    }
+                    else if (string.Equals(field.Name, enumText, StringComparison.OrdinalIgnoreCase))
+                    {
+                        return (T)(field.GetValue(null) ?? default(T));
+                    }
+                }
+
+                // If not found, try parsing directly
+                if (Enum.TryParse(enumText, true, out T result))
+                {
+                    return result;
+                }
+            }
+            else if (reader.TokenType == JsonTokenType.Number)
+            {
+                if (reader.TryGetInt32(out int intValue))
+                {
+                    return (T)(object)intValue;
+                }
+            }
+
+            throw new JsonException($"Unable to convert \"{reader.GetString()}\" to enum \"{typeof(T)}\".");
+        }
+
+        public override void Write(Utf8JsonWriter writer, T value, JsonSerializerOptions options)
+        {
+            var field = typeof(T).GetField(value.ToString());
+            if (field?.GetCustomAttribute<EnumMemberAttribute>() is EnumMemberAttribute attribute)
+            {
+                writer.WriteStringValue(attribute.Value);
+            }
+            else
+            {
+                writer.WriteStringValue(value.ToString());
+            }
+        }
+    }
+}

--- a/src/NoFrixion.MoneyMoov/JsonConverters/JsonStringEnumMemberConverter.cs
+++ b/src/NoFrixion.MoneyMoov/JsonConverters/JsonStringEnumMemberConverter.cs
@@ -11,7 +11,7 @@
 // 09 Jun 2024  Aaron Clauson   Created, Stillorgan Wood, Dublin, Ireland.
 //
 // License: 
-// Proprietary NoFrixion.
+// MIT.
 //-----------------------------------------------------------------------------
 
 using System.Reflection;

--- a/src/NoFrixion.MoneyMoov/JsonConverters/JsonStringEnumMemberConverter.cs
+++ b/src/NoFrixion.MoneyMoov/JsonConverters/JsonStringEnumMemberConverter.cs
@@ -2,7 +2,8 @@
 // Filename: JsonStringEnumMemberConverter.cs
 //
 // Description: Converter for deserialsing strings to enums. Allows both the enum
-// value and the member attribute to be used as the string value.
+// value and the member attribute to be used as the string value. This converter
+// is only required for System.Text.Json as Newtonsoft already supports this.
 //
 // Author(s):
 // Aaron Clauson

--- a/src/NoFrixion.MoneyMoov/JsonConverters/NumericConverter.cs
+++ b/src/NoFrixion.MoneyMoov/JsonConverters/NumericConverter.cs
@@ -13,6 +13,7 @@
 // MIT.
 //-----------------------------------------------------------------------------
 
+using LanguageExt;
 using System.ComponentModel;
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -64,6 +65,17 @@ public class NumericConverter<T> : JsonConverter<T> where T : struct, IConvertib
 
     public override void Write(Utf8JsonWriter writer, T value, JsonSerializerOptions options)
     {
-        writer.WriteStringValue(value.ToString());
+        if (typeof(T) == typeof(int))
+            writer.WriteNumberValue(Convert.ToInt32(value));
+        else if (typeof(T) == typeof(long))
+            writer.WriteNumberValue(Convert.ToInt64(value));
+        else if (typeof(T) == typeof(float))
+            writer.WriteNumberValue(Convert.ToSingle(value));
+        else if (typeof(T) == typeof(double))
+            writer.WriteNumberValue(Convert.ToDouble(value));
+        else if (typeof(T) == typeof(decimal))
+            writer.WriteNumberValue(Convert.ToDecimal(value));
+        else
+            writer.WriteStringValue(value.ToString());
     }
 }

--- a/src/NoFrixion.MoneyMoov/JsonConverters/NumericConverter.cs
+++ b/src/NoFrixion.MoneyMoov/JsonConverters/NumericConverter.cs
@@ -1,7 +1,8 @@
 ﻿//-----------------------------------------------------------------------------
 // Filename: NumericConverter.cs
 //
-// Description: Converter for deserialsing strings numeric values.
+// Description: Converter for deserialsing strings numeric values. This converter
+// is only required for System.Text.Json as Newtonsoft already supports this.
 //
 // Author(s):
 // Aaron Clauson

--- a/src/NoFrixion.MoneyMoov/JsonConverters/NumericConverter.cs
+++ b/src/NoFrixion.MoneyMoov/JsonConverters/NumericConverter.cs
@@ -10,7 +10,7 @@
 // 09 Jun 2024  Aaron Clauson   Created, Stillorgan Wood, Dublin, Ireland.
 //
 // License: 
-// Proprietary NoFrixion.
+// MIT.
 //-----------------------------------------------------------------------------
 
 using System.ComponentModel;
@@ -67,4 +67,3 @@ public class NumericConverter<T> : JsonConverter<T> where T : struct, IConvertib
         writer.WriteStringValue(value.ToString());
     }
 }
-

--- a/src/NoFrixion.MoneyMoov/JsonConverters/NumericConverter.cs
+++ b/src/NoFrixion.MoneyMoov/JsonConverters/NumericConverter.cs
@@ -1,0 +1,70 @@
+﻿//-----------------------------------------------------------------------------
+// Filename: NumericConverter.cs
+//
+// Description: Converter for deserialsing strings numeric values.
+//
+// Author(s):
+// Aaron Clauson
+// 
+// History:
+// 09 Jun 2024  Aaron Clauson   Created, Stillorgan Wood, Dublin, Ireland.
+//
+// License: 
+// Proprietary NoFrixion.
+//-----------------------------------------------------------------------------
+
+using System.ComponentModel;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace NoFrixion.MoneyMoov.Json;
+
+public class NumericConverter<T> : JsonConverter<T> where T : struct, IConvertible
+{
+    public override T Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+    {
+        if (reader.TokenType == JsonTokenType.String)
+        {
+            var stringValue = reader.GetString();
+            if (string.IsNullOrEmpty(stringValue))
+            {
+                return default; // Handle empty strings as null/zero equivalent
+            }
+            try
+            {
+                return (T)(TypeDescriptor.GetConverter(typeof(T)).ConvertFromInvariantString(stringValue) ?? default(T));
+            }
+            catch (Exception ex)
+            {
+                throw new JsonException($"Unable to convert \"{stringValue}\" to {typeof(T)}.", ex);
+            }
+        }
+
+        if (reader.TokenType == JsonTokenType.Number)
+        {
+            if (typeof(T) == typeof(int))
+                return (T)(object)reader.GetInt32();
+            if (typeof(T) == typeof(long))
+                return (T)(object)reader.GetInt64();
+            if (typeof(T) == typeof(float))
+                return (T)(object)reader.GetSingle();
+            if (typeof(T) == typeof(double))
+                return (T)(object)reader.GetDouble();
+            if (typeof(T) == typeof(decimal))
+                return (T)(object)reader.GetDecimal();
+        }
+
+        if (reader.TokenType == JsonTokenType.Null)
+        {
+            return default; // Handle null values as default(T)
+        }
+
+        throw new JsonException($"Unexpected token type {reader.TokenType} when parsing {typeof(T)}.");
+    }
+
+    public override void Write(Utf8JsonWriter writer, T value, JsonSerializerOptions options)
+    {
+        writer.WriteStringValue(value.ToString());
+    }
+}
+

--- a/src/NoFrixion.MoneyMoov/Mapping/CsvMapper.cs
+++ b/src/NoFrixion.MoneyMoov/Mapping/CsvMapper.cs
@@ -100,7 +100,7 @@ public static class CsvMapper
                                 {
                                     if (!string.IsNullOrEmpty(formattedValue))
                                     {
-                                        var stringItems = Newtonsoft.Json.JsonConvert.DeserializeObject<List<string>>(formattedValue);
+                                        var stringItems = System.Text.Json.JsonSerializer.Deserialize<List<string>>(formattedValue);
                                         property.SetValue(result.Model, stringItems);
                                     }
                                 }

--- a/src/NoFrixion.MoneyMoov/Mapping/CsvMapper.cs
+++ b/src/NoFrixion.MoneyMoov/Mapping/CsvMapper.cs
@@ -100,7 +100,7 @@ public static class CsvMapper
                                 {
                                     if (!string.IsNullOrEmpty(formattedValue))
                                     {
-                                        var stringItems = System.Text.Json.JsonSerializer.Deserialize<List<string>>(formattedValue);
+                                        var stringItems = formattedValue.FromJson<List<string>>();
                                         property.SetValue(result.Model, stringItems);
                                     }
                                 }

--- a/src/NoFrixion.MoneyMoov/Models/Account/AccountIdentifier.cs
+++ b/src/NoFrixion.MoneyMoov/Models/Account/AccountIdentifier.cs
@@ -14,6 +14,7 @@
 // -----------------------------------------------------------------------------
 
 using System.ComponentModel.DataAnnotations;
+using System.Text.Json.Serialization;
 
 namespace NoFrixion.MoneyMoov.Models;
 
@@ -24,7 +25,7 @@ public class AccountIdentifier: IValidatableObject
     /// <summary>
     /// The type of the account identifier.
     /// </summary>
-    [Newtonsoft.Json.JsonConverter(typeof(Newtonsoft.Json.Converters.StringEnumConverter))]
+    [JsonConverter(typeof(JsonStringEnumConverter))]
     public AccountIdentifierType Type
     {
         get

--- a/src/NoFrixion.MoneyMoov/Models/Account/AccountIdentifier.cs
+++ b/src/NoFrixion.MoneyMoov/Models/Account/AccountIdentifier.cs
@@ -14,7 +14,6 @@
 // -----------------------------------------------------------------------------
 
 using System.ComponentModel.DataAnnotations;
-using System.Text.Json.Serialization;
 
 namespace NoFrixion.MoneyMoov.Models;
 
@@ -25,7 +24,6 @@ public class AccountIdentifier: IValidatableObject
     /// <summary>
     /// The type of the account identifier.
     /// </summary>
-    [JsonConverter(typeof(JsonStringEnumConverter))]
     public AccountIdentifierType Type
     {
         get

--- a/src/NoFrixion.MoneyMoov/Models/ApiPageResponseBase.cs
+++ b/src/NoFrixion.MoneyMoov/Models/ApiPageResponseBase.cs
@@ -12,9 +12,10 @@
 //  Proprietary NoFrixion.
 // -----------------------------------------------------------------------------
 
-using Newtonsoft.Json;
+using System.Text.Json;
 using NoFrixion.MoneyMoov.Models.Utils;
 using System.Text;
+using System.Text.Json.Serialization;
 
 namespace NoFrixion.MoneyMoov.Models;
 
@@ -131,6 +132,11 @@ public abstract class ApiPageResponseBase<T> : PageResponse<T>
     /// <returns>JSON string presentation of the object</returns>
     public virtual string ToJson()
     {
-        return JsonConvert.SerializeObject(this, Formatting.Indented);
+        var options = new JsonSerializerOptions
+        {
+            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+            WriteIndented = true
+        };
+        return JsonSerializer.Serialize(this, options);
     }
 }

--- a/src/NoFrixion.MoneyMoov/Models/ApiPageResponseBase.cs
+++ b/src/NoFrixion.MoneyMoov/Models/ApiPageResponseBase.cs
@@ -12,10 +12,8 @@
 //  Proprietary NoFrixion.
 // -----------------------------------------------------------------------------
 
-using System.Text.Json;
 using NoFrixion.MoneyMoov.Models.Utils;
 using System.Text;
-using System.Text.Json.Serialization;
 
 namespace NoFrixion.MoneyMoov.Models;
 
@@ -131,12 +129,5 @@ public abstract class ApiPageResponseBase<T> : PageResponse<T>
     /// </summary>
     /// <returns>JSON string presentation of the object</returns>
     public virtual string ToJson()
-    {
-        var options = new JsonSerializerOptions
-        {
-            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
-            WriteIndented = true
-        };
-        return JsonSerializer.Serialize(this, options);
-    }
+        => this.ToJsonFormatted();
 }

--- a/src/NoFrixion.MoneyMoov/Models/Beneficiary/Beneficiary.cs
+++ b/src/NoFrixion.MoneyMoov/Models/Beneficiary/Beneficiary.cs
@@ -16,7 +16,8 @@
 
 using System.ComponentModel.DataAnnotations;
 using JetBrains.Annotations;
-using Newtonsoft.Json;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
 #nullable disable
 namespace NoFrixion.MoneyMoov.Models;
@@ -97,7 +98,7 @@ public class Beneficiary : IValidatableObject
     public User CreatedBy { get; set; }
 
     // Don't serialize the events if there are none.
-    [JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     public virtual IEnumerable<BeneficiaryEvent> BeneficiaryEvents { get; set; }
 
     public virtual IEnumerable<PaymentAccount> SourceAccounts { get; set; }

--- a/src/NoFrixion.MoneyMoov/Models/Beneficiary/Beneficiary.cs
+++ b/src/NoFrixion.MoneyMoov/Models/Beneficiary/Beneficiary.cs
@@ -16,8 +16,8 @@
 
 using System.ComponentModel.DataAnnotations;
 using JetBrains.Annotations;
-using System.Text.Json;
 using System.Text.Json.Serialization;
+using Newtonsoft.Json;
 
 #nullable disable
 namespace NoFrixion.MoneyMoov.Models;
@@ -98,7 +98,8 @@ public class Beneficiary : IValidatableObject
     public User CreatedBy { get; set; }
 
     // Don't serialize the events if there are none.
-    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [System.Text.Json.Serialization.JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [Newtonsoft.Json.JsonProperty(NullValueHandling = NullValueHandling.Ignore)]
     public virtual IEnumerable<BeneficiaryEvent> BeneficiaryEvents { get; set; }
 
     public virtual IEnumerable<PaymentAccount> SourceAccounts { get; set; }

--- a/src/NoFrixion.MoneyMoov/Models/Mandates/Mandate.cs
+++ b/src/NoFrixion.MoneyMoov/Models/Mandates/Mandate.cs
@@ -15,8 +15,7 @@
 // -----------------------------------------------------------------------------
 
 using System.ComponentModel.DataAnnotations;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Converters;
+using System.Text.Json.Serialization;
 
 namespace NoFrixion.MoneyMoov.Models.Mandates;
 
@@ -40,7 +39,7 @@ public class Mandate
     /// Name of the supplier used to create this mandate.
     /// </summary>
     [EnumDataType(typeof(PaymentProcessorsEnum))]
-    [JsonConverter(typeof(StringEnumConverter))]
+    [JsonConverter(typeof(JsonStringEnumConverter))]
     public PaymentProcessorsEnum? SupplierName { get; set; }
     
     /// <summary>
@@ -119,7 +118,7 @@ public class Mandate
     /// Currency of this mandate.
     /// </summary>
     [EnumDataType(typeof(CurrencyTypeEnum))]
-    [JsonConverter(typeof(StringEnumConverter))]
+    [JsonConverter(typeof(JsonStringEnumConverter))]
     public CurrencyTypeEnum Currency { get; set; }
     
     /// <summary>
@@ -141,7 +140,7 @@ public class Mandate
     /// General status of this mandate.
     /// </summary>
     [EnumDataType(typeof(MerchantMandateStatusEnum))]
-    [JsonConverter(typeof(StringEnumConverter))]
+    [JsonConverter(typeof(JsonStringEnumConverter))]
     public MerchantMandateStatusEnum Status { get; set; }
     
     /// <summary>

--- a/src/NoFrixion.MoneyMoov/Models/Mandates/Mandate.cs
+++ b/src/NoFrixion.MoneyMoov/Models/Mandates/Mandate.cs
@@ -14,9 +14,6 @@
 //  MIT.
 // -----------------------------------------------------------------------------
 
-using System.ComponentModel.DataAnnotations;
-using System.Text.Json.Serialization;
-
 namespace NoFrixion.MoneyMoov.Models.Mandates;
 
 /// <summary>
@@ -38,8 +35,6 @@ public class Mandate
     /// <summary>
     /// Name of the supplier used to create this mandate.
     /// </summary>
-    [EnumDataType(typeof(PaymentProcessorsEnum))]
-    [JsonConverter(typeof(JsonStringEnumConverter))]
     public PaymentProcessorsEnum? SupplierName { get; set; }
     
     /// <summary>
@@ -117,8 +112,6 @@ public class Mandate
     /// <summary>
     /// Currency of this mandate.
     /// </summary>
-    [EnumDataType(typeof(CurrencyTypeEnum))]
-    [JsonConverter(typeof(JsonStringEnumConverter))]
     public CurrencyTypeEnum Currency { get; set; }
     
     /// <summary>
@@ -139,8 +132,6 @@ public class Mandate
     /// <summary>
     /// General status of this mandate.
     /// </summary>
-    [EnumDataType(typeof(MerchantMandateStatusEnum))]
-    [JsonConverter(typeof(JsonStringEnumConverter))]
     public MerchantMandateStatusEnum Status { get; set; }
     
     /// <summary>

--- a/src/NoFrixion.MoneyMoov/Models/Merchant/Merchant.cs
+++ b/src/NoFrixion.MoneyMoov/Models/Merchant/Merchant.cs
@@ -15,8 +15,6 @@
 // MIT.
 // -----------------------------------------------------------------------------
 
-using System.Text.Json;
-
 namespace NoFrixion.MoneyMoov.Models;
 
 public class Merchant

--- a/src/NoFrixion.MoneyMoov/Models/Merchant/Merchant.cs
+++ b/src/NoFrixion.MoneyMoov/Models/Merchant/Merchant.cs
@@ -15,7 +15,7 @@
 // MIT.
 // -----------------------------------------------------------------------------
 
-using Newtonsoft.Json;
+using System.Text.Json;
 
 namespace NoFrixion.MoneyMoov.Models;
 

--- a/src/NoFrixion.MoneyMoov/Models/Merchant/MerchantPayByBankSetting.cs
+++ b/src/NoFrixion.MoneyMoov/Models/Merchant/MerchantPayByBankSetting.cs
@@ -13,9 +13,6 @@
 //  MIT.
 // -----------------------------------------------------------------------------
 
-using System.ComponentModel.DataAnnotations;
-using System.Text.Json.Serialization;
-
 namespace NoFrixion.MoneyMoov.Models;
 
 /// <summary>
@@ -46,15 +43,11 @@ public class MerchantPayByBankSetting
     /// <summary>
     /// Currency supported by the bank.
     /// </summary>
-    [EnumDataType(typeof(CurrencyTypeEnum))]
-    [JsonConverter(typeof(JsonStringEnumConverter))]
     public CurrencyTypeEnum Currency { get; set; }
 
     /// <summary>
     /// Name of the bank payment processor.
     /// </summary>
-    [EnumDataType(typeof(PaymentProcessorsEnum))]
-    [JsonConverter(typeof(JsonStringEnumConverter))]
     public PaymentProcessorsEnum Processor { get; set; }
 
     /// <summary>

--- a/src/NoFrixion.MoneyMoov/Models/Merchant/MerchantPayByBankSetting.cs
+++ b/src/NoFrixion.MoneyMoov/Models/Merchant/MerchantPayByBankSetting.cs
@@ -14,8 +14,7 @@
 // -----------------------------------------------------------------------------
 
 using System.ComponentModel.DataAnnotations;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Converters;
+using System.Text.Json.Serialization;
 
 namespace NoFrixion.MoneyMoov.Models;
 
@@ -48,14 +47,14 @@ public class MerchantPayByBankSetting
     /// Currency supported by the bank.
     /// </summary>
     [EnumDataType(typeof(CurrencyTypeEnum))]
-    [JsonConverter(typeof(StringEnumConverter))]
+    [JsonConverter(typeof(JsonStringEnumConverter))]
     public CurrencyTypeEnum Currency { get; set; }
 
     /// <summary>
     /// Name of the bank payment processor.
     /// </summary>
     [EnumDataType(typeof(PaymentProcessorsEnum))]
-    [JsonConverter(typeof(StringEnumConverter))]
+    [JsonConverter(typeof(JsonStringEnumConverter))]
     public PaymentProcessorsEnum Processor { get; set; }
 
     /// <summary>

--- a/src/NoFrixion.MoneyMoov/Models/Metadata/EchoMessage.cs
+++ b/src/NoFrixion.MoneyMoov/Models/Metadata/EchoMessage.cs
@@ -1,0 +1,19 @@
+﻿// -----------------------------------------------------------------------------
+// Filename: EchoMessage.cs
+// 
+// Description: Model to represent a message that can be "echoed" back from
+// the MoneyMoov Metadata API controller.
+// 
+// Author(s):
+// Aaron Clauson (aaron@nofrixion.com)
+// 
+// History:
+// 09 Jun 2024  Aaron Clauson   Migrated from main API project.
+// 
+// License:
+// MIT.
+// -----------------------------------------------------------------------------
+
+namespace NoFrixion.MoneyMoov.Models;
+
+public record EchoMessage(string Name, string Message);

--- a/src/NoFrixion.MoneyMoov/Models/OpenBanking/Account.cs
+++ b/src/NoFrixion.MoneyMoov/Models/OpenBanking/Account.cs
@@ -110,7 +110,5 @@ public partial class Account
     }
 
     public virtual string ToJson()
-    {
-        return Newtonsoft.Json.JsonConvert.SerializeObject(this, Newtonsoft.Json.Formatting.Indented);
-    }
+        => this.ToJsonFormatted();
 }

--- a/src/NoFrixion.MoneyMoov/Models/OpenBanking/AccountBalance.cs
+++ b/src/NoFrixion.MoneyMoov/Models/OpenBanking/AccountBalance.cs
@@ -55,7 +55,5 @@ public partial class AccountBalance
     /// </summary>
     /// <returns>JSON string presentation of the object</returns>
     public virtual string ToJson()
-    {
-        return Newtonsoft.Json.JsonConvert.SerializeObject(this, Newtonsoft.Json.Formatting.Indented);
-    }
+        => this.ToJsonFormatted();
 }

--- a/src/NoFrixion.MoneyMoov/Models/OpenBanking/AccountBalanceType.cs
+++ b/src/NoFrixion.MoneyMoov/Models/OpenBanking/AccountBalanceType.cs
@@ -1,13 +1,11 @@
 
 using System.Runtime.Serialization;
-using System.Text.Json.Serialization;
 
 namespace NoFrixion.MoneyMoov.Models.OpenBanking;
 
 /// <summary>
 /// Specifies the type of the stated account balance.
 /// </summary>
-[JsonConverter(typeof(JsonStringEnumConverter))]
 public enum AccountBalanceType
 {
     [EnumMember(Value = "CLOSING_AVAILABLE")]

--- a/src/NoFrixion.MoneyMoov/Models/OpenBanking/AccountBalanceType.cs
+++ b/src/NoFrixion.MoneyMoov/Models/OpenBanking/AccountBalanceType.cs
@@ -1,14 +1,13 @@
 
 using System.Runtime.Serialization;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Converters;
+using System.Text.Json.Serialization;
 
 namespace NoFrixion.MoneyMoov.Models.OpenBanking;
 
 /// <summary>
 /// Specifies the type of the stated account balance.
 /// </summary>
-[JsonConverter(typeof(StringEnumConverter))]
+[JsonConverter(typeof(JsonStringEnumConverter))]
 public enum AccountBalanceType
 {
     [EnumMember(Value = "CLOSING_AVAILABLE")]

--- a/src/NoFrixion.MoneyMoov/Models/OpenBanking/AccountIdentification.cs
+++ b/src/NoFrixion.MoneyMoov/Models/OpenBanking/AccountIdentification.cs
@@ -27,7 +27,5 @@ public partial class AccountIdentification
     }
 
     public virtual string ToJson()
-    {
-        return Newtonsoft.Json.JsonConvert.SerializeObject(this, Newtonsoft.Json.Formatting.Indented);
-    }
+        => this.ToJsonFormatted();
 }

--- a/src/NoFrixion.MoneyMoov/Models/OpenBanking/AccountIdentificationType.cs
+++ b/src/NoFrixion.MoneyMoov/Models/OpenBanking/AccountIdentificationType.cs
@@ -1,10 +1,8 @@
 
 using System.Runtime.Serialization;
-using System.Text.Json.Serialization;
 
 namespace NoFrixion.MoneyMoov.Models.OpenBanking;
 
-[JsonConverter(typeof(JsonStringEnumConverter))]
 public enum AccountIdentificationType
 {
     [EnumMember(Value = "SORT_CODE")]

--- a/src/NoFrixion.MoneyMoov/Models/OpenBanking/AccountIdentificationType.cs
+++ b/src/NoFrixion.MoneyMoov/Models/OpenBanking/AccountIdentificationType.cs
@@ -1,11 +1,10 @@
 
 using System.Runtime.Serialization;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Converters;
+using System.Text.Json.Serialization;
 
 namespace NoFrixion.MoneyMoov.Models.OpenBanking;
 
-[JsonConverter(typeof(StringEnumConverter))]
+[JsonConverter(typeof(JsonStringEnumConverter))]
 public enum AccountIdentificationType
 {
     [EnumMember(Value = "SORT_CODE")]

--- a/src/NoFrixion.MoneyMoov/Models/OpenBanking/AccountName.cs
+++ b/src/NoFrixion.MoneyMoov/Models/OpenBanking/AccountName.cs
@@ -25,7 +25,5 @@ public partial class AccountName
     }
 
     public virtual string ToJson()
-    {
-        return Newtonsoft.Json.JsonConvert.SerializeObject(this, Newtonsoft.Json.Formatting.Indented);
-    }
+        => this.ToJsonFormatted();
 }

--- a/src/NoFrixion.MoneyMoov/Models/OpenBanking/AddressDetails.cs
+++ b/src/NoFrixion.MoneyMoov/Models/OpenBanking/AddressDetails.cs
@@ -25,7 +25,5 @@ public partial class AddressDetails
     }
 
     public virtual string ToJson()
-    {
-        return Newtonsoft.Json.JsonConvert.SerializeObject(this, Newtonsoft.Json.Formatting.Indented);
-    }
+        => this.ToJsonFormatted();
 }

--- a/src/NoFrixion.MoneyMoov/Models/OpenBanking/AddressTypeEnum.cs
+++ b/src/NoFrixion.MoneyMoov/Models/OpenBanking/AddressTypeEnum.cs
@@ -1,10 +1,8 @@
 
 using System.Runtime.Serialization;
-using System.Text.Json.Serialization;
 
 namespace NoFrixion.MoneyMoov.Models.OpenBanking;
 
-[JsonConverter(typeof(JsonStringEnumConverter))]
 public enum AddressTypeEnum
 {
     [EnumMember(Value = "BUSINESS")]

--- a/src/NoFrixion.MoneyMoov/Models/OpenBanking/AddressTypeEnum.cs
+++ b/src/NoFrixion.MoneyMoov/Models/OpenBanking/AddressTypeEnum.cs
@@ -1,11 +1,10 @@
 
 using System.Runtime.Serialization;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Converters;
+using System.Text.Json.Serialization;
 
 namespace NoFrixion.MoneyMoov.Models.OpenBanking;
 
-[JsonConverter(typeof(StringEnumConverter))]
+[JsonConverter(typeof(JsonStringEnumConverter))]
 public enum AddressTypeEnum
 {
     [EnumMember(Value = "BUSINESS")]

--- a/src/NoFrixion.MoneyMoov/Models/OpenBanking/Amount.cs
+++ b/src/NoFrixion.MoneyMoov/Models/OpenBanking/Amount.cs
@@ -30,7 +30,5 @@ public partial class Amount
     }
 
     public virtual string ToJson()
-    {
-        return Newtonsoft.Json.JsonConvert.SerializeObject(this, Newtonsoft.Json.Formatting.Indented);
-    }
+        => this.ToJsonFormatted();
 }

--- a/src/NoFrixion.MoneyMoov/Models/OpenBanking/ConsolidatedAccountInformation.cs
+++ b/src/NoFrixion.MoneyMoov/Models/OpenBanking/ConsolidatedAccountInformation.cs
@@ -36,7 +36,5 @@ public partial class ConsolidatedAccountInformation
     }
 
     public virtual string ToJson()
-    {
-        return Newtonsoft.Json.JsonConvert.SerializeObject(this, Newtonsoft.Json.Formatting.Indented);
-    }
+        => this.ToJsonFormatted();
 }

--- a/src/NoFrixion.MoneyMoov/Models/OpenBanking/CreditLine.cs
+++ b/src/NoFrixion.MoneyMoov/Models/OpenBanking/CreditLine.cs
@@ -31,7 +31,5 @@ public partial class CreditLine
     }
 
     public virtual string ToJson()
-    {
-        return Newtonsoft.Json.JsonConvert.SerializeObject(this, Newtonsoft.Json.Formatting.Indented);
-    }
+        => this.ToJsonFormatted();
 }

--- a/src/NoFrixion.MoneyMoov/Models/OpenBanking/CreditLineType.cs
+++ b/src/NoFrixion.MoneyMoov/Models/OpenBanking/CreditLineType.cs
@@ -1,11 +1,10 @@
 
 using System.Runtime.Serialization;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Converters;
+using System.Text.Json.Serialization;
 
 namespace NoFrixion.MoneyMoov.Models.OpenBanking;
 
-[JsonConverter(typeof(StringEnumConverter))]
+[JsonConverter(typeof(JsonStringEnumConverter))]
 public enum CreditLineType
 {
     [EnumMember(Value = "AVAILABLE")]

--- a/src/NoFrixion.MoneyMoov/Models/OpenBanking/CreditLineType.cs
+++ b/src/NoFrixion.MoneyMoov/Models/OpenBanking/CreditLineType.cs
@@ -1,10 +1,8 @@
 
 using System.Runtime.Serialization;
-using System.Text.Json.Serialization;
 
 namespace NoFrixion.MoneyMoov.Models.OpenBanking;
 
-[JsonConverter(typeof(JsonStringEnumConverter))]
 public enum CreditLineType
 {
     [EnumMember(Value = "AVAILABLE")]

--- a/src/NoFrixion.MoneyMoov/Models/OpenBanking/CurrencyExchange.cs
+++ b/src/NoFrixion.MoneyMoov/Models/OpenBanking/CurrencyExchange.cs
@@ -52,7 +52,5 @@ public class CurrencyExchange
     }
 
     public virtual string ToJson()
-    {
-        return Newtonsoft.Json.JsonConvert.SerializeObject(this, Newtonsoft.Json.Formatting.Indented);
-    }
+        => this.ToJsonFormatted();
 }

--- a/src/NoFrixion.MoneyMoov/Models/OpenBanking/IsoCodeDetails.cs
+++ b/src/NoFrixion.MoneyMoov/Models/OpenBanking/IsoCodeDetails.cs
@@ -27,7 +27,5 @@ public partial class IsoCodeDetails
     }
 
     public virtual string ToJson()
-    {
-        return Newtonsoft.Json.JsonConvert.SerializeObject(this, Newtonsoft.Json.Formatting.Indented);
-    } 
+        => this.ToJsonFormatted();
 }

--- a/src/NoFrixion.MoneyMoov/Models/OpenBanking/Payee.cs
+++ b/src/NoFrixion.MoneyMoov/Models/OpenBanking/Payee.cs
@@ -54,7 +54,5 @@ public partial class Payee
     }
 
     public virtual string ToJson()
-    {
-        return Newtonsoft.Json.JsonConvert.SerializeObject(this, Newtonsoft.Json.Formatting.Indented);
-    }
+        => this.ToJsonFormatted();
 }

--- a/src/NoFrixion.MoneyMoov/Models/OpenBanking/PayeeDetails.cs
+++ b/src/NoFrixion.MoneyMoov/Models/OpenBanking/PayeeDetails.cs
@@ -39,7 +39,5 @@ public partial class PayeeDetails
     }
 
     public virtual string ToJson()
-    {
-        return Newtonsoft.Json.JsonConvert.SerializeObject(this, Newtonsoft.Json.Formatting.Indented);
-    }
+        => this.ToJsonFormatted();
 }

--- a/src/NoFrixion.MoneyMoov/Models/OpenBanking/Payer.cs
+++ b/src/NoFrixion.MoneyMoov/Models/OpenBanking/Payer.cs
@@ -36,7 +36,5 @@ public partial class Payer
     }
 
     public virtual string ToJson()
-    {
-        return Newtonsoft.Json.JsonConvert.SerializeObject(this, Newtonsoft.Json.Formatting.Indented);
-    }
+        => this.ToJsonFormatted();
 }

--- a/src/NoFrixion.MoneyMoov/Models/OpenBanking/PayerDetails.cs
+++ b/src/NoFrixion.MoneyMoov/Models/OpenBanking/PayerDetails.cs
@@ -23,7 +23,5 @@ public partial class PayerDetails
     }
 
     public virtual string ToJson()
-    {
-        return Newtonsoft.Json.JsonConvert.SerializeObject(this, Newtonsoft.Json.Formatting.Indented);
-    }
+        => this.ToJsonFormatted();
 }

--- a/src/NoFrixion.MoneyMoov/Models/OpenBanking/ProprietaryBankTransactionCode.cs
+++ b/src/NoFrixion.MoneyMoov/Models/OpenBanking/ProprietaryBankTransactionCode.cs
@@ -27,7 +27,5 @@ public partial class ProprietaryBankTransactionCode
     }
 
     public virtual string ToJson()
-    {
-        return Newtonsoft.Json.JsonConvert.SerializeObject(this, Newtonsoft.Json.Formatting.Indented);
-    }
+        => this.ToJsonFormatted();
 }

--- a/src/NoFrixion.MoneyMoov/Models/OpenBanking/StatementReference.cs
+++ b/src/NoFrixion.MoneyMoov/Models/OpenBanking/StatementReference.cs
@@ -22,7 +22,5 @@ public partial class StatementReference
     }
 
     public virtual string ToJson()
-    {
-        return Newtonsoft.Json.JsonConvert.SerializeObject(this, Newtonsoft.Json.Formatting.Indented);
-    }
+        => this.ToJsonFormatted();
 }

--- a/src/NoFrixion.MoneyMoov/Models/OpenBanking/Transaction.cs
+++ b/src/NoFrixion.MoneyMoov/Models/OpenBanking/Transaction.cs
@@ -123,7 +123,5 @@ public partial class Transaction
     }
 
     public virtual string ToJson()
-    {
-        return Newtonsoft.Json.JsonConvert.SerializeObject(this, Newtonsoft.Json.Formatting.Indented);
-    }
+        => this.ToJsonFormatted();
 }

--- a/src/NoFrixion.MoneyMoov/Models/OpenBanking/TransactionBalance.cs
+++ b/src/NoFrixion.MoneyMoov/Models/OpenBanking/TransactionBalance.cs
@@ -28,7 +28,5 @@ public partial class TransactionBalance
     }
 
     public virtual string ToJson()
-    {
-        return Newtonsoft.Json.JsonConvert.SerializeObject(this, Newtonsoft.Json.Formatting.Indented);
-    }
+        => this.ToJsonFormatted();
 }

--- a/src/NoFrixion.MoneyMoov/Models/OpenBanking/TransactionChargeDetails.cs
+++ b/src/NoFrixion.MoneyMoov/Models/OpenBanking/TransactionChargeDetails.cs
@@ -20,7 +20,5 @@ public partial class TransactionChargeDetails
     }
 
     public virtual string ToJson()
-    {
-        return Newtonsoft.Json.JsonConvert.SerializeObject(this, Newtonsoft.Json.Formatting.Indented);
-    }
+        => this.ToJsonFormatted();
 }

--- a/src/NoFrixion.MoneyMoov/Models/OpenBanking/TransactionStatusEnum.cs
+++ b/src/NoFrixion.MoneyMoov/Models/OpenBanking/TransactionStatusEnum.cs
@@ -1,10 +1,8 @@
 
 using System.Runtime.Serialization;
-using System.Text.Json.Serialization;
 
 namespace NoFrixion.MoneyMoov.Models.OpenBanking;
 
-[JsonConverter(typeof(JsonStringEnumConverter))]
 public enum TransactionStatusEnum
 {
     [EnumMember(Value = "BOOKED")]

--- a/src/NoFrixion.MoneyMoov/Models/OpenBanking/TransactionStatusEnum.cs
+++ b/src/NoFrixion.MoneyMoov/Models/OpenBanking/TransactionStatusEnum.cs
@@ -1,11 +1,10 @@
 
 using System.Runtime.Serialization;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Converters;
+using System.Text.Json.Serialization;
 
 namespace NoFrixion.MoneyMoov.Models.OpenBanking;
 
-[JsonConverter(typeof(StringEnumConverter))]
+[JsonConverter(typeof(JsonStringEnumConverter))]
 public enum TransactionStatusEnum
 {
     [EnumMember(Value = "BOOKED")]

--- a/src/NoFrixion.MoneyMoov/Models/PaymentRequests/PaymentRequest.cs
+++ b/src/NoFrixion.MoneyMoov/Models/PaymentRequests/PaymentRequest.cs
@@ -22,8 +22,7 @@
 //-----------------------------------------------------------------------------
 
 using System.ComponentModel.DataAnnotations;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Converters;
+using System.Text.Json.Serialization;
 using NoFrixion.MoneyMoov.Extensions;
 
 namespace NoFrixion.MoneyMoov.Models;
@@ -43,7 +42,7 @@ public class PaymentRequest : IPaymentRequest, IWebhookPayload
     /// The currency of the request.
     /// </summary>
     [EnumDataType(typeof(CurrencyTypeEnum))]
-    [JsonConverter(typeof(StringEnumConverter))]
+    [JsonConverter(typeof(JsonStringEnumConverter))]
     public CurrencyTypeEnum Currency { get; set; } = CurrencyTypeEnum.EUR;
 
     /// <summary>
@@ -62,7 +61,7 @@ public class PaymentRequest : IPaymentRequest, IWebhookPayload
     /// should be supplied as a comma separated list, for example "card, pisp, lightning".
     /// </summary>
     [EnumDataType(typeof(PaymentMethodTypeEnum))]
-    [JsonConverter(typeof(StringEnumConverter))]
+    [JsonConverter(typeof(JsonStringEnumConverter))]
     public PaymentMethodTypeEnum PaymentMethodTypes { get; set; } = PaymentMethodTypeEnum.card;
 
     /// <summary>
@@ -232,7 +231,6 @@ public class PaymentRequest : IPaymentRequest, IWebhookPayload
     public string? CardStripePaymentIntentSecret { get; set; }
 
     [JsonIgnore]
-    [System.Text.Json.Serialization.JsonIgnore]
     public Merchant? Merchant { get; set; }
 
     public List<PaymentRequestAddress> Addresses { get; set; } = new List<PaymentRequestAddress>();

--- a/src/NoFrixion.MoneyMoov/Models/PaymentRequests/PaymentRequest.cs
+++ b/src/NoFrixion.MoneyMoov/Models/PaymentRequests/PaymentRequest.cs
@@ -230,7 +230,8 @@ public class PaymentRequest : IPaymentRequest, IWebhookPayload
     /// </summary>
     public string? CardStripePaymentIntentSecret { get; set; }
 
-    [JsonIgnore]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonProperty]
     public Merchant? Merchant { get; set; }
 
     public List<PaymentRequestAddress> Addresses { get; set; } = new List<PaymentRequestAddress>();
@@ -274,7 +275,8 @@ public class PaymentRequest : IPaymentRequest, IWebhookPayload
     /// Attempts to get the billing address for this payment request.
     /// </summary>
     /// <returns>The billing address or null if it's not set.</returns>
-    [JsonIgnore]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonProperty]
     public PaymentRequestAddress? BillingAddress =>
         Addresses?.Where(x => x.AddressType == AddressTypesEnum.Billing).FirstOrDefault();
 

--- a/src/NoFrixion.MoneyMoov/Models/PaymentRequests/PaymentRequest.cs
+++ b/src/NoFrixion.MoneyMoov/Models/PaymentRequests/PaymentRequest.cs
@@ -22,7 +22,6 @@
 //-----------------------------------------------------------------------------
 
 using System.ComponentModel.DataAnnotations;
-using System.Text.Json.Serialization;
 using NoFrixion.MoneyMoov.Extensions;
 
 namespace NoFrixion.MoneyMoov.Models;
@@ -41,8 +40,6 @@ public class PaymentRequest : IPaymentRequest, IWebhookPayload
     /// <summary>
     /// The currency of the request.
     /// </summary>
-    [EnumDataType(typeof(CurrencyTypeEnum))]
-    [JsonConverter(typeof(JsonStringEnumConverter))]
     public CurrencyTypeEnum Currency { get; set; } = CurrencyTypeEnum.EUR;
 
     /// <summary>
@@ -60,8 +57,6 @@ public class PaymentRequest : IPaymentRequest, IWebhookPayload
     /// The payment methods that the payment request supports. When setting using form data
     /// should be supplied as a comma separated list, for example "card, pisp, lightning".
     /// </summary>
-    [EnumDataType(typeof(PaymentMethodTypeEnum))]
-    [JsonConverter(typeof(JsonStringEnumConverter))]
     public PaymentMethodTypeEnum PaymentMethodTypes { get; set; } = PaymentMethodTypeEnum.card;
 
     /// <summary>

--- a/src/NoFrixion.MoneyMoov/Models/PaymentRequests/PaymentRequestCreate.cs
+++ b/src/NoFrixion.MoneyMoov/Models/PaymentRequests/PaymentRequestCreate.cs
@@ -15,7 +15,6 @@
 
 using NoFrixion.MoneyMoov.Attributes;
 using System.ComponentModel.DataAnnotations;
-using System.Text.Json.Serialization;
 
 namespace NoFrixion.MoneyMoov.Models;
 
@@ -40,8 +39,6 @@ public class PaymentRequestCreate : IValidatableObject, IPaymentRequest
     /// <summary>
     /// The currency of the payment request.
     /// </summary>
-    [EnumDataType(typeof(CurrencyTypeEnum))]
-    [JsonConverter(typeof(JsonStringEnumConverter))]
     public CurrencyTypeEnum Currency { get; set; } = CurrencyTypeEnum.EUR;
 
     /// <summary>
@@ -65,8 +62,6 @@ public class PaymentRequestCreate : IValidatableObject, IPaymentRequest
     /// The payment methods that the payment request supports. When setting using form data
     /// should be supplied as a comma separated list, for example "card, pisp, lightning".
     /// </summary>
-    [EnumDataType(typeof(PaymentMethodTypeEnum))]
-    [JsonConverter(typeof(JsonStringEnumConverter))]
     public PaymentMethodTypeEnum PaymentMethodTypes { get; set; } = PaymentMethodTypeEnum.card;
 
     /// <summary>

--- a/src/NoFrixion.MoneyMoov/Models/PaymentRequests/PaymentRequestCreate.cs
+++ b/src/NoFrixion.MoneyMoov/Models/PaymentRequests/PaymentRequestCreate.cs
@@ -13,10 +13,9 @@
 // MIT.
 //-----------------------------------------------------------------------------
 
-using Newtonsoft.Json;
-using Newtonsoft.Json.Converters;
 using NoFrixion.MoneyMoov.Attributes;
 using System.ComponentModel.DataAnnotations;
+using System.Text.Json.Serialization;
 
 namespace NoFrixion.MoneyMoov.Models;
 
@@ -42,7 +41,7 @@ public class PaymentRequestCreate : IValidatableObject, IPaymentRequest
     /// The currency of the payment request.
     /// </summary>
     [EnumDataType(typeof(CurrencyTypeEnum))]
-    [JsonConverter(typeof(StringEnumConverter))]
+    [JsonConverter(typeof(JsonStringEnumConverter))]
     public CurrencyTypeEnum Currency { get; set; } = CurrencyTypeEnum.EUR;
 
     /// <summary>
@@ -67,7 +66,7 @@ public class PaymentRequestCreate : IValidatableObject, IPaymentRequest
     /// should be supplied as a comma separated list, for example "card, pisp, lightning".
     /// </summary>
     [EnumDataType(typeof(PaymentMethodTypeEnum))]
-    [JsonConverter(typeof(StringEnumConverter))]
+    [JsonConverter(typeof(JsonStringEnumConverter))]
     public PaymentMethodTypeEnum PaymentMethodTypes { get; set; } = PaymentMethodTypeEnum.card;
 
     /// <summary>

--- a/src/NoFrixion.MoneyMoov/Models/PaymentRequests/PaymentRequestCreate.cs
+++ b/src/NoFrixion.MoneyMoov/Models/PaymentRequests/PaymentRequestCreate.cs
@@ -290,13 +290,16 @@ public class PaymentRequestCreate : IValidatableObject, IPaymentRequest
     [OptionalEmailAddress]
     public string? CustomerEmailAddress { get; set; }
 
-    [JsonIgnore]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonProperty]
     public PaymentProcessorsEnum PaymentProcessor { get; set; }
 
-    [JsonIgnore]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonProperty]
     public string? LightningInvoice { get; set; }
 
-    [JsonIgnore]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonProperty]
     public DateTimeOffset? LightningInvoiceExpiresAt { get; set; }
     
     [EmailAddressMultiple(ErrorMessage = PaymentRequestConstants.NOTIFICATION_EMAIL_ADDRESSES_ERROR_MESSAGE)]

--- a/src/NoFrixion.MoneyMoov/Models/PaymentRequests/PaymentRequestEvent.cs
+++ b/src/NoFrixion.MoneyMoov/Models/PaymentRequests/PaymentRequestEvent.cs
@@ -17,7 +17,7 @@
 // MIT.
 //-----------------------------------------------------------------------------
 
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 using System.ComponentModel.DataAnnotations;
 
 namespace NoFrixion.MoneyMoov.Models;
@@ -44,11 +44,9 @@ public class PaymentRequestEvent
     public string? ErrorMessage { get; set; }
 
     [JsonIgnore]
-    [System.Text.Json.Serialization.JsonIgnore]
     public string? RawResponse { get; set; }
 
     [JsonIgnore]
-    [System.Text.Json.Serialization.JsonIgnore]
     public string? RawResponseHash { get; set; }
 
     public string? CardRequestID { get; set; }
@@ -101,7 +99,6 @@ public class PaymentRequestEvent
     /// between submitting and finalising a payment initiation attempt.
     /// </summary>
     [JsonIgnore]
-    [System.Text.Json.Serialization.JsonIgnore]
     public string? PispToken { get; set; }
 
     /// <summary>
@@ -139,7 +136,6 @@ public class PaymentRequestEvent
     /// of the tokenised card record that can be used with the pay with card token method.
     /// </summary>
     [JsonIgnore]
-    [System.Text.Json.Serialization.JsonIgnore]
     public Guid? TokenisedCardID { get; set; }
 
     /// <summary>

--- a/src/NoFrixion.MoneyMoov/Models/PaymentRequests/PaymentRequestEvent.cs
+++ b/src/NoFrixion.MoneyMoov/Models/PaymentRequests/PaymentRequestEvent.cs
@@ -43,10 +43,12 @@ public class PaymentRequestEvent
 
     public string? ErrorMessage { get; set; }
 
-    [JsonIgnore]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonProperty]
     public string? RawResponse { get; set; }
 
-    [JsonIgnore]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonProperty]
     public string? RawResponseHash { get; set; }
 
     public string? CardRequestID { get; set; }
@@ -98,7 +100,8 @@ public class PaymentRequestEvent
     /// For payment initiation providers that use an OAuth, or other, token to create a session
     /// between submitting and finalising a payment initiation attempt.
     /// </summary>
-    [JsonIgnore]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonProperty]
     public string? PispToken { get; set; }
 
     /// <summary>
@@ -135,7 +138,8 @@ public class PaymentRequestEvent
     /// If a reusable card token was generated as part of the event this will hold the ID
     /// of the tokenised card record that can be used with the pay with card token method.
     /// </summary>
-    [JsonIgnore]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonProperty]
     public Guid? TokenisedCardID { get; set; }
 
     /// <summary>

--- a/src/NoFrixion.MoneyMoov/Models/PaymentRequests/PaymentRequestMinimal.cs
+++ b/src/NoFrixion.MoneyMoov/Models/PaymentRequests/PaymentRequestMinimal.cs
@@ -13,9 +13,6 @@
 //  MIT.
 // -----------------------------------------------------------------------------
 
-using System.ComponentModel.DataAnnotations;
-using System.Text.Json.Serialization;
-
 namespace NoFrixion.MoneyMoov.Models;
 
 public class PaymentRequestMinimal
@@ -36,8 +33,6 @@ public class PaymentRequestMinimal
     /// <summary>
     /// The currency of the request.
     /// </summary>
-    [EnumDataType(typeof(CurrencyTypeEnum))]
-    [JsonConverter(typeof(JsonStringEnumConverter))]
     public CurrencyTypeEnum Currency { get; set; } = CurrencyTypeEnum.EUR;
 
     /// <summary>
@@ -54,7 +49,6 @@ public class PaymentRequestMinimal
     /// <summary>
     /// The card processor
     /// </summary>
-    [JsonConverter(typeof(JsonStringEnumConverter))]
     public PaymentProcessorsEnum PaymentProcessor { get; set; }
 
     /// <summary>

--- a/src/NoFrixion.MoneyMoov/Models/PaymentRequests/PaymentRequestMinimal.cs
+++ b/src/NoFrixion.MoneyMoov/Models/PaymentRequests/PaymentRequestMinimal.cs
@@ -14,8 +14,7 @@
 // -----------------------------------------------------------------------------
 
 using System.ComponentModel.DataAnnotations;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Converters;
+using System.Text.Json.Serialization;
 
 namespace NoFrixion.MoneyMoov.Models;
 
@@ -38,7 +37,7 @@ public class PaymentRequestMinimal
     /// The currency of the request.
     /// </summary>
     [EnumDataType(typeof(CurrencyTypeEnum))]
-    [JsonConverter(typeof(StringEnumConverter))]
+    [JsonConverter(typeof(JsonStringEnumConverter))]
     public CurrencyTypeEnum Currency { get; set; } = CurrencyTypeEnum.EUR;
 
     /// <summary>
@@ -55,7 +54,7 @@ public class PaymentRequestMinimal
     /// <summary>
     /// The card processor
     /// </summary>
-    [JsonConverter(typeof(StringEnumConverter))]
+    [JsonConverter(typeof(JsonStringEnumConverter))]
     public PaymentProcessorsEnum PaymentProcessor { get; set; }
 
     /// <summary>

--- a/src/NoFrixion.MoneyMoov/Models/PaymentRequests/PaymentRequestUpdate.cs
+++ b/src/NoFrixion.MoneyMoov/Models/PaymentRequests/PaymentRequestUpdate.cs
@@ -14,10 +14,9 @@
 //  MIT.
 // -----------------------------------------------------------------------------
 
-using Newtonsoft.Json.Converters;
 using NoFrixion.MoneyMoov.Attributes;
 using System.ComponentModel.DataAnnotations;
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace NoFrixion.MoneyMoov.Models;
 
@@ -48,7 +47,7 @@ public class PaymentRequestUpdate
     /// should be supplied as a comma separated list, for example "card, pisp, lightning".
     /// </summary>
     [EnumDataType(typeof(PaymentMethodTypeEnum))]
-    [JsonConverter(typeof(StringEnumConverter))]
+    [JsonConverter(typeof(JsonStringEnumConverter))]
     public PaymentMethodTypeEnum? PaymentMethodTypes { get; set; }
 
     /// <summary>

--- a/src/NoFrixion.MoneyMoov/Models/PaymentRequests/PaymentRequestUpdate.cs
+++ b/src/NoFrixion.MoneyMoov/Models/PaymentRequests/PaymentRequestUpdate.cs
@@ -16,7 +16,6 @@
 
 using NoFrixion.MoneyMoov.Attributes;
 using System.ComponentModel.DataAnnotations;
-using System.Text.Json.Serialization;
 
 namespace NoFrixion.MoneyMoov.Models;
 
@@ -46,8 +45,6 @@ public class PaymentRequestUpdate
     /// The payment methods that the payment request supports. When setting using form data
     /// should be supplied as a comma separated list, for example "card, pisp, lightning".
     /// </summary>
-    [EnumDataType(typeof(PaymentMethodTypeEnum))]
-    [JsonConverter(typeof(JsonStringEnumConverter))]
     public PaymentMethodTypeEnum? PaymentMethodTypes { get; set; }
 
     /// <summary>

--- a/src/NoFrixion.MoneyMoov/Models/Payouts/Payout.cs
+++ b/src/NoFrixion.MoneyMoov/Models/Payouts/Payout.cs
@@ -96,6 +96,7 @@ public class Payout : IValidatableObject, IWebhookPayload
     
     [Obsolete("Please use Destination.")]
     [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonProperty]
     public Guid? DestinationAccountID
     {
         get => Destination?.AccountID;
@@ -108,6 +109,7 @@ public class Payout : IValidatableObject, IWebhookPayload
 
     [Obsolete("Please use Destination.")]
     [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonProperty]
     public string? DestinationIBAN
     {
         get => Destination?.Identifier?.IBAN;
@@ -121,6 +123,7 @@ public class Payout : IValidatableObject, IWebhookPayload
 
     [Obsolete("Please use Destination.")]
     [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonProperty]
     public string? DestinationAccountNumber
     {
         get => Destination?.Identifier?.AccountNumber;
@@ -134,6 +137,7 @@ public class Payout : IValidatableObject, IWebhookPayload
 
     [Obsolete("Please use Destination.")]
     [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonProperty]
     public string? DestinationSortCode
     {
         get => Destination?.Identifier?.SortCode;
@@ -147,6 +151,7 @@ public class Payout : IValidatableObject, IWebhookPayload
 
     [Obsolete("Please use Destination.")]
     [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonProperty]
     public string? DestinationAccountName
     {
         get => Destination?.Name;
@@ -245,6 +250,7 @@ public class Payout : IValidatableObject, IWebhookPayload
 
     [Obsolete("Please use Destination.")]
     [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonProperty]
     public Counterparty? DestinationAccount
     {
         get => Destination;

--- a/src/NoFrixion.MoneyMoov/Models/Token/MerchantToken.cs
+++ b/src/NoFrixion.MoneyMoov/Models/Token/MerchantToken.cs
@@ -14,9 +14,8 @@
 //  MIT.
 // -----------------------------------------------------------------------------
 
-using Newtonsoft.Json.Converters;
 using System.ComponentModel.DataAnnotations;
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace NoFrixion.MoneyMoov.Models;
 
@@ -31,7 +30,7 @@ public class MerchantToken
     public string Description { get; set; }
 
     [EnumDataType(typeof(MerchantTokenPermissionsEnum))]
-    [JsonConverter(typeof(StringEnumConverter))]
+    [JsonConverter(typeof(JsonStringEnumConverter))]
     public MerchantTokenPermissionsEnum Permissions { get; set; }
 
     public DateTimeOffset Inserted { get; set; }

--- a/src/NoFrixion.MoneyMoov/Models/Token/MerchantToken.cs
+++ b/src/NoFrixion.MoneyMoov/Models/Token/MerchantToken.cs
@@ -14,9 +14,6 @@
 //  MIT.
 // -----------------------------------------------------------------------------
 
-using System.ComponentModel.DataAnnotations;
-using System.Text.Json.Serialization;
-
 namespace NoFrixion.MoneyMoov.Models;
 
 #nullable disable
@@ -29,8 +26,6 @@ public class MerchantToken
 
     public string Description { get; set; }
 
-    [EnumDataType(typeof(MerchantTokenPermissionsEnum))]
-    [JsonConverter(typeof(JsonStringEnumConverter))]
     public MerchantTokenPermissionsEnum Permissions { get; set; }
 
     public DateTimeOffset Inserted { get; set; }

--- a/src/NoFrixion.MoneyMoov/Models/Token/TokenAdd.cs
+++ b/src/NoFrixion.MoneyMoov/Models/Token/TokenAdd.cs
@@ -12,10 +12,9 @@
 //  MIT.
 // -----------------------------------------------------------------------------
 
-using Newtonsoft.Json;
-using Newtonsoft.Json.Converters;
 using System.ComponentModel.DataAnnotations;
 using System.Text.RegularExpressions;
+using System.Text.Json.Serialization;
 
 namespace NoFrixion.MoneyMoov.Models;
 
@@ -36,7 +35,7 @@ public class TokenAdd : IValidatableObject
     public string Description { get; set; }
 
     [EnumDataType(typeof(MerchantTokenPermissionsEnum))]
-    [JsonConverter(typeof(StringEnumConverter))]
+    [JsonConverter(typeof(JsonStringEnumConverter))]
     public MerchantTokenPermissionsEnum Permissions { get; set; } = MerchantTokenPermissionsEnum.CreatePaymentRequest;
 
     public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)

--- a/src/NoFrixion.MoneyMoov/Models/Token/TokenAdd.cs
+++ b/src/NoFrixion.MoneyMoov/Models/Token/TokenAdd.cs
@@ -14,8 +14,6 @@
 
 using System.ComponentModel.DataAnnotations;
 using System.Text.RegularExpressions;
-using System.Text.Json.Serialization;
-
 namespace NoFrixion.MoneyMoov.Models;
 
 #nullable disable
@@ -34,8 +32,6 @@ public class TokenAdd : IValidatableObject
     [Required(ErrorMessage = "Description is required")]
     public string Description { get; set; }
 
-    [EnumDataType(typeof(MerchantTokenPermissionsEnum))]
-    [JsonConverter(typeof(JsonStringEnumConverter))]
     public MerchantTokenPermissionsEnum Permissions { get; set; } = MerchantTokenPermissionsEnum.CreatePaymentRequest;
 
     public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)

--- a/src/NoFrixion.MoneyMoov/Models/Transaction/Transaction.cs
+++ b/src/NoFrixion.MoneyMoov/Models/Transaction/Transaction.cs
@@ -16,9 +16,8 @@
 
 #nullable disable
 
-using Newtonsoft.Json;
-using Newtonsoft.Json.Converters;
 using System.ComponentModel.DataAnnotations;
+using System.Text.Json.Serialization;
 
 namespace NoFrixion.MoneyMoov.Models;
 
@@ -59,7 +58,7 @@ public class Transaction : IWebhookPayload
     /// Currency of transaction.
     /// </summary>
     [EnumDataType(typeof(CurrencyTypeEnum))]
-    [JsonConverter(typeof(StringEnumConverter))]
+    [JsonConverter(typeof(JsonStringEnumConverter))]
     public CurrencyTypeEnum Currency { get; set; }
 
     /// <summary>

--- a/src/NoFrixion.MoneyMoov/Models/Transaction/Transaction.cs
+++ b/src/NoFrixion.MoneyMoov/Models/Transaction/Transaction.cs
@@ -16,9 +16,6 @@
 
 #nullable disable
 
-using System.ComponentModel.DataAnnotations;
-using System.Text.Json.Serialization;
-
 namespace NoFrixion.MoneyMoov.Models;
 
 public class Transaction : IWebhookPayload
@@ -57,8 +54,6 @@ public class Transaction : IWebhookPayload
     /// <summary>
     /// Currency of transaction.
     /// </summary>
-    [EnumDataType(typeof(CurrencyTypeEnum))]
-    [JsonConverter(typeof(JsonStringEnumConverter))]
     public CurrencyTypeEnum Currency { get; set; }
 
     /// <summary>

--- a/src/NoFrixion.MoneyMoov/Models/Utils/PageResponse.cs
+++ b/src/NoFrixion.MoneyMoov/Models/Utils/PageResponse.cs
@@ -1,4 +1,5 @@
-﻿using Newtonsoft.Json;
+﻿using System.Text.Json;
+using System.Text.Json.Serialization;
 
 #nullable disable
 
@@ -6,35 +7,35 @@ namespace NoFrixion.MoneyMoov.Models.Utils
 {
     public class PageResponse<T>
     {
-        [JsonProperty("content")]
+        [JsonPropertyName("content")]
         public List<T> Content { get; set; } = new();
 
         /// <summary>
         /// Current page number. Its 1 based. i.e firstpage is 1, secondpage is 2 
         /// </summary>
         /// <value>Current page number. Its 1 based. i.e first page is 1, second page is 2</value>
-        [JsonProperty("pageNumber")]
+        [JsonPropertyName("pageNumber")]
         public int PageNumber { get; set; }
 
         /// <summary>
         /// Page size
         /// </summary>
         /// <value>Page size</value>
-        [JsonProperty("pageSize")]
+        [JsonPropertyName("pageSize")]
         public int PageSize { get; set; }
 
         /// <summary>
         /// Total pages
         /// </summary>
         /// <value>Total pages</value>
-        [JsonProperty("totalPages")]
+        [JsonPropertyName("totalPages")]
         public int TotalPages { get; set; }
 
         /// <summary>
         /// Total count
         /// </summary>
         /// <value>Total count</value>
-        [JsonProperty("totalSize")]
+        [JsonPropertyName("totalSize")]
         public long TotalSize { get; set; }
     }
 }

--- a/src/NoFrixion.MoneyMoov/Models/Utils/PageResponse.cs
+++ b/src/NoFrixion.MoneyMoov/Models/Utils/PageResponse.cs
@@ -1,41 +1,34 @@
-﻿using System.Text.Json;
-using System.Text.Json.Serialization;
-
+﻿
 #nullable disable
 
 namespace NoFrixion.MoneyMoov.Models.Utils
 {
     public class PageResponse<T>
     {
-        [JsonPropertyName("content")]
         public List<T> Content { get; set; } = new();
 
         /// <summary>
         /// Current page number. Its 1 based. i.e firstpage is 1, secondpage is 2 
         /// </summary>
         /// <value>Current page number. Its 1 based. i.e first page is 1, second page is 2</value>
-        [JsonPropertyName("pageNumber")]
         public int PageNumber { get; set; }
 
         /// <summary>
         /// Page size
         /// </summary>
         /// <value>Page size</value>
-        [JsonPropertyName("pageSize")]
         public int PageSize { get; set; }
 
         /// <summary>
         /// Total pages
         /// </summary>
         /// <value>Total pages</value>
-        [JsonPropertyName("totalPages")]
         public int TotalPages { get; set; }
 
         /// <summary>
         /// Total count
         /// </summary>
         /// <value>Total count</value>
-        [JsonPropertyName("totalSize")]
         public long TotalSize { get; set; }
     }
 }

--- a/src/NoFrixion.MoneyMoov/Models/WebHook/WebhookEventItem.cs
+++ b/src/NoFrixion.MoneyMoov/Models/WebHook/WebhookEventItem.cs
@@ -13,9 +13,8 @@
 // MIT.
 //-----------------------------------------------------------------------------
 
-using Newtonsoft.Json;
-using Newtonsoft.Json.Converters;
 using System.ComponentModel.DataAnnotations;
+using System.Text.Json.Serialization;
 
 namespace NoFrixion.MoneyMoov.Models;
 
@@ -31,7 +30,7 @@ public class WebhookEventItem
     /// deleted etc.
     /// </summary>
     [EnumDataType(typeof(WebhookActionsEnum))]
-    [JsonConverter(typeof(StringEnumConverter))]
+    [JsonConverter(typeof(JsonStringEnumConverter))]
     public WebhookActionsEnum ActionType { get; set; }
 
     /// <summary>
@@ -39,7 +38,7 @@ public class WebhookEventItem
     /// payload, transaction etc.
     /// </summary>
     [EnumDataType(typeof(WebhookResourceTypesEnum))]
-    [JsonConverter(typeof(StringEnumConverter))]
+    [JsonConverter(typeof(JsonStringEnumConverter))]
     public WebhookResourceTypesEnum ResourceType { get; set; }
 
     /// <summary>
@@ -59,4 +58,3 @@ public class WebhookEventItem
         Payload = payload;
     }
 }
-

--- a/src/NoFrixion.MoneyMoov/Models/WebHook/WebhookEventItem.cs
+++ b/src/NoFrixion.MoneyMoov/Models/WebHook/WebhookEventItem.cs
@@ -13,9 +13,6 @@
 // MIT.
 //-----------------------------------------------------------------------------
 
-using System.ComponentModel.DataAnnotations;
-using System.Text.Json.Serialization;
-
 namespace NoFrixion.MoneyMoov.Models;
 
 public class WebhookEventItem
@@ -29,16 +26,12 @@ public class WebhookEventItem
     /// The type of event the webhook is for, for example created, updated,
     /// deleted etc.
     /// </summary>
-    [EnumDataType(typeof(WebhookActionsEnum))]
-    [JsonConverter(typeof(JsonStringEnumConverter))]
     public WebhookActionsEnum ActionType { get; set; }
 
     /// <summary>
     /// The type of resource the webhook item represents, for example
     /// payload, transaction etc.
     /// </summary>
-    [EnumDataType(typeof(WebhookResourceTypesEnum))]
-    [JsonConverter(typeof(JsonStringEnumConverter))]
     public WebhookResourceTypesEnum ResourceType { get; set; }
 
     /// <summary>

--- a/src/NoFrixion.MoneyMoov/MoneyMoovJson.cs
+++ b/src/NoFrixion.MoneyMoov/MoneyMoovJson.cs
@@ -61,6 +61,7 @@ public class MoneyMoovJson
             ReferenceLoopHandling = ReferenceLoopHandling.Ignore,
             NullValueHandling = NullValueHandling.Ignore,
             Formatting = writeIndented ? Formatting.Indented : Formatting.None,
+            ObjectCreationHandling = ObjectCreationHandling.Replace,
             Converters =
             {
                 new Newtonsoft.Json.Converters.StringEnumConverter(),

--- a/src/NoFrixion.MoneyMoov/MoneyMoovJson.cs
+++ b/src/NoFrixion.MoneyMoov/MoneyMoovJson.cs
@@ -21,7 +21,7 @@ namespace NoFrixion.MoneyMoov;
 
 public class MoneyMoovJson
 {
-    public static JsonSerializerOptions GetSerialiserOptions(bool writeIndented = false)
+    public static JsonSerializerOptions GetSystemTextSerialiserOptions(bool writeIndented = false)
     {
         return new JsonSerializerOptions
         {

--- a/src/NoFrixion.MoneyMoov/MoneyMoovJson.cs
+++ b/src/NoFrixion.MoneyMoov/MoneyMoovJson.cs
@@ -1,0 +1,55 @@
+﻿//-----------------------------------------------------------------------------
+// Filename:  MoneyNoovJsonS.cs
+//
+// Description: JSON serialiser options for wotking with the MoneyMoov API.
+//
+// Author(s):
+// Aaron Clauson
+// 
+// History:
+// 09 Jun 2024  Aaron Clauson   Created, Stillorgan Wood, Dublin, Ireland.
+//
+// License: 
+// MIT.
+//-----------------------------------------------------------------------------
+
+using NoFrixion.MoneyMoov.Json;
+using System.Text.Json.Serialization;
+using System.Text.Json;
+
+namespace NoFrixion.MoneyMoov;
+
+public class MoneyMoovJson
+{
+    public static JsonSerializerOptions GetSerialiserOptions(bool writeIndented = false)
+    {
+        return new JsonSerializerOptions
+        {
+            PropertyNameCaseInsensitive = true,
+
+            // Set the JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull) attribute on properties to ignore null values.
+            //DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull, 
+
+            ReferenceHandler = ReferenceHandler.IgnoreCycles,
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            DictionaryKeyPolicy = JsonNamingPolicy.CamelCase,
+            WriteIndented = writeIndented,
+            Converters =
+            {
+                // Allow enum values or member attribute values,e.g. [EnumMember(Value = "xxx")] to be deserialised from strings.
+                new JsonStringEnumMemberConverter(),
+
+                // Allows "true" and "false" strings to be deserialised to booleans.
+                new BooleanAsStringConverter(),
+
+                // Newtonsoft allows numeric values to be deserialised from strings.
+                // This is not the default behaviour in System.Text.Json so use a custom converter.
+                new NumericConverter<int>(),
+                new NumericConverter<long>(),
+                new NumericConverter<float>(),
+                new NumericConverter<double>(),
+                new NumericConverter<decimal>()
+            }
+        };
+    }
+}

--- a/src/NoFrixion.MoneyMoov/MoneyMoovJson.cs
+++ b/src/NoFrixion.MoneyMoov/MoneyMoovJson.cs
@@ -1,5 +1,5 @@
 ﻿//-----------------------------------------------------------------------------
-// Filename:  MoneyNoovJsonS.cs
+// Filename:  MoneyNoovJson.cs
 //
 // Description: JSON serialiser options for wotking with the MoneyMoov API.
 //

--- a/src/NoFrixion.MoneyMoov/MoneyMoovJson.cs
+++ b/src/NoFrixion.MoneyMoov/MoneyMoovJson.cs
@@ -33,7 +33,6 @@ public class MoneyMoovJson
 
             ReferenceHandler = ReferenceHandler.IgnoreCycles,
             PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-            DictionaryKeyPolicy = JsonNamingPolicy.CamelCase,
             WriteIndented = writeIndented,
             Converters =
             {

--- a/src/NoFrixion.MoneyMoov/MoneyMoovJson.cs
+++ b/src/NoFrixion.MoneyMoov/MoneyMoovJson.cs
@@ -13,6 +13,7 @@
 // MIT.
 //-----------------------------------------------------------------------------
 
+using Newtonsoft.Json;
 using NoFrixion.MoneyMoov.Json;
 using System.Text.Json.Serialization;
 using System.Text.Json;
@@ -49,6 +50,21 @@ public class MoneyMoovJson
                 new NumericConverter<float>(),
                 new NumericConverter<double>(),
                 new NumericConverter<decimal>()
+            }
+        };
+    }
+
+    public static JsonSerializerSettings GetNewtonsoftSerialiserSettings(bool writeIndented = false)
+    {
+        return new JsonSerializerSettings
+        {
+            ReferenceLoopHandling = ReferenceLoopHandling.Ignore,
+            NullValueHandling = NullValueHandling.Ignore,
+            Formatting = writeIndented ? Formatting.Indented : Formatting.None,
+            Converters =
+            {
+                new Newtonsoft.Json.Converters.StringEnumConverter(),
+                new Newtonsoft.Json.Converters.IsoDateTimeConverter()
             }
         };
     }

--- a/src/NoFrixion.MoneyMoov/MoneyMoovJson.cs
+++ b/src/NoFrixion.MoneyMoov/MoneyMoovJson.cs
@@ -17,6 +17,7 @@ using Newtonsoft.Json;
 using NoFrixion.MoneyMoov.Json;
 using System.Text.Json.Serialization;
 using System.Text.Json;
+using Newtonsoft.Json.Serialization;
 
 namespace NoFrixion.MoneyMoov;
 
@@ -27,10 +28,7 @@ public class MoneyMoovJson
         return new JsonSerializerOptions
         {
             PropertyNameCaseInsensitive = true,
-
-            // Set the JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull) attribute on properties to ignore null values.
-            //DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull, 
-
+            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull, 
             ReferenceHandler = ReferenceHandler.IgnoreCycles,
             PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
             WriteIndented = writeIndented,
@@ -61,10 +59,10 @@ public class MoneyMoovJson
             NullValueHandling = NullValueHandling.Ignore,
             Formatting = writeIndented ? Formatting.Indented : Formatting.None,
             ObjectCreationHandling = ObjectCreationHandling.Replace,
+            ContractResolver = new CamelCasePropertyNamesContractResolver(),
             Converters =
             {
-                new Newtonsoft.Json.Converters.StringEnumConverter(),
-                new Newtonsoft.Json.Converters.IsoDateTimeConverter()
+                new Newtonsoft.Json.Converters.StringEnumConverter()
             }
         };
     }

--- a/src/NoFrixion.MoneyMoov/NoFrixion.MoneyMoov.csproj
+++ b/src/NoFrixion.MoneyMoov/NoFrixion.MoneyMoov.csproj
@@ -20,6 +20,7 @@
         <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
         <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
         <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="7.6.0" />
+        <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
         <PackageReference Include="Quartz" Version="3.9.0" />
     </ItemGroup>
 

--- a/src/NoFrixion.MoneyMoov/NoFrixion.MoneyMoov.csproj
+++ b/src/NoFrixion.MoneyMoov/NoFrixion.MoneyMoov.csproj
@@ -20,7 +20,6 @@
         <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
         <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
         <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="7.6.0" />
-        <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
         <PackageReference Include="Quartz" Version="3.9.0" />
     </ItemGroup>
 

--- a/src/NoFrixion.MoneyMoov/NoFrixionProblem.cs
+++ b/src/NoFrixion.MoneyMoov/NoFrixionProblem.cs
@@ -23,6 +23,7 @@
 using System.ComponentModel.DataAnnotations;
 using System.Net;
 using System.Runtime.Serialization;
+using System.Text.Json;
 using System.Text.Json.Serialization;
 
 namespace NoFrixion.MoneyMoov;
@@ -378,11 +379,6 @@ public class NoFrixionProblem
 
     public static NoFrixionProblem FromJson(string json)
     {
-       return Newtonsoft.Json.JsonConvert.DeserializeObject<NoFrixionProblem>(json,
-            new Newtonsoft.Json.JsonSerializerSettings
-            {
-                ObjectCreationHandling = Newtonsoft.Json.ObjectCreationHandling.Replace
-            }) 
-            ?? NoFrixionProblem.Empty;
+       return JsonSerializer.Deserialize<NoFrixionProblem>(json) ?? NoFrixionProblem.Empty;
     }
 }

--- a/src/NoFrixion.MoneyMoov/NoFrixionProblem.cs
+++ b/src/NoFrixion.MoneyMoov/NoFrixionProblem.cs
@@ -292,7 +292,7 @@ public class NoFrixionProblem
     }
 
     public string ToJson() =>
-        System.Text.Json.JsonSerializer.Serialize(this);
+        this.ToJsonFormatted();
 
     /// <summary>
     /// Plain text representation of the problem.
@@ -379,6 +379,6 @@ public class NoFrixionProblem
 
     public static NoFrixionProblem FromJson(string json)
     {
-       return JsonSerializer.Deserialize<NoFrixionProblem>(json) ?? NoFrixionProblem.Empty;
+       return json.FromJson<NoFrixionProblem>() ?? NoFrixionProblem.Empty;
     }
 }

--- a/src/NoFrixion.MoneyMoov/NoFrixionProblem.cs
+++ b/src/NoFrixion.MoneyMoov/NoFrixionProblem.cs
@@ -23,7 +23,6 @@
 using System.ComponentModel.DataAnnotations;
 using System.Net;
 using System.Runtime.Serialization;
-using System.Text.Json;
 using System.Text.Json.Serialization;
 
 namespace NoFrixion.MoneyMoov;
@@ -147,7 +146,6 @@ public class NoFrixionProblem
     /// <example>
     /// https://tools.ietf.org/html/rfc7231#section-6.5.1
     /// </example>
-    [JsonPropertyName("type")]
     public string Type { get; set; } = ProblemDefaults.Defaults[(int)HttpStatusCode.BadRequest].Type;
 
     /// <summary>
@@ -158,7 +156,6 @@ public class NoFrixionProblem
     /// <example>
     /// Bad Request
     /// </example>
-    [JsonPropertyName("title")]
     public string Title { get; set; } = ProblemDefaults.Defaults[(int)HttpStatusCode.BadRequest].Title;
 
     /// <summary>
@@ -173,7 +170,6 @@ public class NoFrixionProblem
     /// 501 Not Implemented.
     /// etc.
     /// </example>
-    [JsonPropertyName("status")]
     public int Status { get; set; }
 
     /// <summary>
@@ -182,17 +178,14 @@ public class NoFrixionProblem
     /// <example>
     /// Something went wrong with your request and this is a useful explanation of what happened.
     /// </example>
-    [JsonPropertyName("detail")]
     public string Detail { get; set; } = string.Empty;
 
     /// <summary>
     /// A URI reference that identifies the specific occurrence of the problem.It may
     /// or may not yield further information if dereferenced.
     /// </summary>
-    [JsonPropertyName("instance")]
     public string Instance { get; set; } = string.Empty;
 
-    [JsonPropertyName("traceid")]
     public string TraceID { get; set; } = string.Empty;
 
     /// <summary>
@@ -202,7 +195,6 @@ public class NoFrixionProblem
     /// chosen to result in the same serialised JSON as will be returned by ASP.NET 
     /// when the parameter on a controller action fails validation.
     /// </summary>
-    [JsonPropertyName("errors")]
     public Dictionary<string, string[]> Errors { get; set; } = new Dictionary<string, string[]>();
 
     /// <summary>
@@ -210,11 +202,13 @@ public class NoFrixionProblem
     /// take copy of the raw error. Mainly useful for REST API responses from server that return an 
     /// unknown, on non-JSON, format.
     /// </summary>
-    [JsonIgnore]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonProperty]
     [IgnoreDataMember]
     public string RawError { get; set; } = string.Empty;
 
-    [JsonIgnore]
+    [System.Text.Json.Serialization.JsonIgnore]
+    [Newtonsoft.Json.JsonProperty]
     [IgnoreDataMember]
     public bool IsEmpty => _isEmpty;
 

--- a/src/NoFrixion.MoneyMoov/RestClient/RestApiClient.cs
+++ b/src/NoFrixion.MoneyMoov/RestClient/RestApiClient.cs
@@ -14,10 +14,10 @@
 //-----------------------------------------------------------------------------
 
 using LanguageExt;
-using LanguageExt.Pipes;
 using System.Net;
 using System.Net.Http.Headers;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace NoFrixion.MoneyMoov;
 
@@ -188,7 +188,7 @@ public class RestApiClient : IRestApiClient, IDisposable
         if (response.IsSuccessStatusCode && response.Content.Headers.ContentLength > 0)
         {
             var jsonString = await response.Content.ReadAsStringAsync();
-            var result = JsonSerializer.Deserialize<T>(jsonString);
+            var result = jsonString.FromJson<T>();
 
             return result != null ?
                 new RestApiResponse<T>(response.StatusCode, requestUri, response.Headers, result) :
@@ -218,7 +218,7 @@ public class RestApiClient : IRestApiClient, IDisposable
     {
         try
         {
-            return JsonSerializer.Deserialize<NoFrixionProblem>(responseContent) ?? NoFrixionProblem.Empty;
+            return responseContent.FromJson<NoFrixionProblem>() ?? NoFrixionProblem.Empty;
         }
         catch (JsonException)
         {
@@ -231,7 +231,7 @@ public class RestApiClient : IRestApiClient, IDisposable
 
     private async Task<RestApiResponse> ExecAsync(
         HttpRequestMessage req,
-        CancellationToken cancellationToken = default(CancellationToken))
+        CancellationToken cancellationToken = default)
     {
         var response = await HttpClient.SendAsync(req, cancellationToken).ConfigureAwait(false);
         return await ToApiResponse(response, req.RequestUri);
@@ -239,7 +239,7 @@ public class RestApiClient : IRestApiClient, IDisposable
 
     private async Task<RestApiResponse<T>> ExecAsync<T>(
         HttpRequestMessage req,
-        CancellationToken cancellationToken = default(CancellationToken))
+        CancellationToken cancellationToken = default)
     {
         var response = await HttpClient.SendAsync(req, cancellationToken).ConfigureAwait(false);
         return await ToApiResponse<T>(response, req.RequestUri);

--- a/src/NoFrixion.MoneyMoov/RestClient/RestApiResponse.cs
+++ b/src/NoFrixion.MoneyMoov/RestClient/RestApiResponse.cs
@@ -61,9 +61,7 @@ public class RestApiResponse
     }
 
     public string ToJson()
-    {
-        return System.Text.Json.JsonSerializer.Serialize(this);
-    }
+        => this.ToJsonFormatted();
 }
 
 /// <summary>

--- a/test/MoneyMoov.IntegrationTests/MetdataClientTests.cs
+++ b/test/MoneyMoov.IntegrationTests/MetdataClientTests.cs
@@ -13,6 +13,7 @@
 // MIT.
 //-----------------------------------------------------------------------------
 
+using LanguageExt.ClassInstances;
 using Microsoft.Extensions.Logging;
 using NoFrixion.MoneyMoov;
 using NoFrixion.MoneyMoov.IntegrationTests;
@@ -183,13 +184,13 @@ public class MetadataClientTests : MoneyMoovTestBase<MetadataClientTests>
         Assert.True(response.Problem.IsEmpty);
 
         response.Data.Match(
-            Some: x =>
+            Some: echoMessage =>
             {
-                var echoResult = System.Text.Json.JsonSerializer.Deserialize<Dictionary<string,string>>(x.ToString());
-                Assert.NotNull(echoResult["name"]);
-                Assert.NotNull(echoResult["message"]);
+                Assert.NotNull(echoMessage);
+                Assert.NotNull(echoMessage.Name);
+                Assert.NotNull(echoMessage.Message);
 
-                Logger.LogDebug($"Echo Result: name={echoResult["name"]}, message={echoResult["message"]}.");
+                Logger.LogDebug($"Echo Result: name={echoMessage.Name}, message={echoMessage.Message}.");
             },
             None: () => throw new ApplicationException("Should not be here")
         ); 

--- a/test/MoneyMoov.IntegrationTests/MetdataClientTests.cs
+++ b/test/MoneyMoov.IntegrationTests/MetdataClientTests.cs
@@ -13,7 +13,6 @@
 // MIT.
 //-----------------------------------------------------------------------------
 
-using LanguageExt.ClassInstances;
 using Microsoft.Extensions.Logging;
 using NoFrixion.MoneyMoov;
 using NoFrixion.MoneyMoov.IntegrationTests;

--- a/test/MoneyMoov.UnitTests/Json/BooleanAsStringConverterTests.cs
+++ b/test/MoneyMoov.UnitTests/Json/BooleanAsStringConverterTests.cs
@@ -1,0 +1,81 @@
+//-----------------------------------------------------------------------------
+// Filename: BooleanAsStringConverterTests.cs
+//
+// Description: Unit tests for the MoneyMoov Json boolean converter class.
+//
+// Author(s):
+// Aaron Clauson (aaron@nofrixion.com)
+// 
+// History:
+// 10 Jun 2024  Aaron Clauson   Created, Harcourt St, Dublin, Ireland.
+//
+// License:  
+// MIT.
+//-----------------------------------------------------------------------------
+
+using System.Text.Json;
+using Xunit;
+
+namespace NoFrixion.MoneyMoov.UnitTests.Json;
+
+public class BooleanAsStringConverterTests
+{
+    private class TestClass
+    {
+        public bool MyBoolean { get; set; }
+    }
+
+    [Theory]
+    [InlineData("\"true\"", true)]
+    [InlineData("\"false\"", false)]
+    [InlineData("\"True\"", true)]
+    [InlineData("\"False\"", false)]
+    [InlineData("\"TRUE\"", true)]
+    [InlineData("\"FALSE\"", false)]
+    [InlineData("true", true)]
+    [InlineData("false", false)]
+    public void Deserialize_Bool_Success(string json, bool expected)
+    {
+        var result = json.FromJson<bool>();
+        Assert.Equal(expected, result);
+    }
+
+    [Theory]
+    [InlineData(true, "true")]
+    [InlineData(false, "false")]
+    public void Serialize_Bool_Success(bool value, string expected)
+    {
+        var json = value.ToJsonFlat();
+        Assert.Equal(expected, json);
+    }
+
+    [Theory]
+    [InlineData("\"notabool\"")]
+    [InlineData("null")]
+    [InlineData("123")]
+    [InlineData("\"123\"")]
+    public void Deserialize_Bool_Failure(string json)
+    {
+        Assert.Throws<JsonException>(() => json.FromJson<bool>());
+    }
+
+    [Theory]
+    [InlineData("{\"MyBoolean\":\"true\"}", true)]
+    [InlineData("{\"MyBoolean\":\"false\"}", false)]
+    public void Deserialize_ClassWithBoolProperty_Success(string json, bool expected)
+    {
+        var result = json.FromJson<TestClass>();
+        Assert.NotNull(result);
+        Assert.Equal(expected, result.MyBoolean);
+    }
+
+    [Theory]
+    [InlineData(true, "{\"myBoolean\":true}")]
+    [InlineData(false, "{\"myBoolean\":false}")]
+    public void Serialize_ClassWithBoolProperty_Success(bool value, string expected)
+    {
+        var myClass = new TestClass { MyBoolean = value };
+        var json = myClass.ToJsonFlat();
+        Assert.Equal(expected, json);
+    }
+}

--- a/test/MoneyMoov.UnitTests/Json/BooleanAsStringConverterTests.cs
+++ b/test/MoneyMoov.UnitTests/Json/BooleanAsStringConverterTests.cs
@@ -13,7 +13,6 @@
 // MIT.
 //-----------------------------------------------------------------------------
 
-using System.Text.Json;
 using Xunit;
 
 namespace NoFrixion.MoneyMoov.UnitTests.Json;
@@ -34,6 +33,9 @@ public class BooleanAsStringConverterTests
     [InlineData("\"FALSE\"", false)]
     [InlineData("true", true)]
     [InlineData("false", false)]
+    [InlineData("1", true)]
+    [InlineData("123", true)]
+    [InlineData("0", false)]
     public void Deserialize_Bool_Success(string json, bool expected)
     {
         var result = json.FromJson<bool>();
@@ -49,14 +51,18 @@ public class BooleanAsStringConverterTests
         Assert.Equal(expected, json);
     }
 
+    [Fact]
+    public void Deserialize_Null_Bool_Failure()
+    {
+        Assert.Throws<Newtonsoft.Json.JsonSerializationException>(() => "null".FromJson<bool>());
+    }
+
     [Theory]
     [InlineData("\"notabool\"")]
-    [InlineData("null")]
-    [InlineData("123")]
     [InlineData("\"123\"")]
     public void Deserialize_Bool_Failure(string json)
     {
-        Assert.Throws<JsonException>(() => json.FromJson<bool>());
+        Assert.Throws<Newtonsoft.Json.JsonReaderException>(() => json.FromJson<bool>());
     }
 
     [Theory]

--- a/test/MoneyMoov.UnitTests/Json/EnumConverterTests.cs
+++ b/test/MoneyMoov.UnitTests/Json/EnumConverterTests.cs
@@ -1,0 +1,55 @@
+//-----------------------------------------------------------------------------
+// Filename: EnumConverterTests.cs
+//
+// Description: Unit tests for the MoneyMoov Json enumconverter class.
+//
+// Author(s):
+// Aaron Clauson (aaron@nofrixion.com)
+// 
+// History:
+// 09 Jun 2024  Aaron Clauson   Created, Stillorgan Wood, Dublin, Ireland.
+//
+// License:  
+// MIT.
+//-----------------------------------------------------------------------------
+
+using System.Runtime.Serialization;
+using Xunit;
+
+namespace NoFrixion.MoneyMoov.UnitTests.Json;
+
+public class EnumConverterTests
+{
+    public enum TestEnum
+    {
+        Unknown = 0,
+
+        [EnumMember(Value = "INT_INTERC")]
+        INTINTERC = 16,
+
+        [EnumMember(Value = "INCOMING_PAYMENT_PROCESSED")]
+        IncomingPaymentProcessed = 1
+    }
+
+    [Theory]
+    [InlineData("\"INT_INTERC\"", TestEnum.INTINTERC)]
+    [InlineData("\"INCOMING_PAYMENT_PROCESSED\"", TestEnum.IncomingPaymentProcessed)]
+    [InlineData("\"Unknown\"", TestEnum.Unknown)]
+    [InlineData("16", TestEnum.INTINTERC)]
+    [InlineData("1", TestEnum.IncomingPaymentProcessed)]
+    public void Deserialise_Enum_Success(string json, TestEnum expected)
+    {
+        var result = json.FromJson<TestEnum>();
+        Assert.Equal(expected, result);
+    }
+
+    [Theory]
+    [InlineData(TestEnum.INTINTERC, "INT_INTERC")]
+    [InlineData(TestEnum.IncomingPaymentProcessed, "INCOMING_PAYMENT_PROCESSED")]
+    [InlineData(TestEnum.Unknown, "Unknown")]
+    public void Serialise_Enum_Success(TestEnum enumValue, string expected)
+    {
+        var json = enumValue.ToJsonFlat();
+        Assert.Equal($"\"{expected}\"", json);
+    }
+}

--- a/test/MoneyMoov.UnitTests/Json/EnumConverterTests.cs
+++ b/test/MoneyMoov.UnitTests/Json/EnumConverterTests.cs
@@ -73,7 +73,7 @@ public class EnumConverterTests
     }
 
     [Theory]
-    [InlineData(null, "{\"instructedamountcurrency\":null}")]
+    //[InlineData(null, "{\"instructedamountcurrency\":null}")]
     [InlineData(TestEnum.INTINTERC, "{\"instructedamountcurrency\":\"INT_INTERC\"}")]
     [InlineData(TestEnum.IncomingPaymentProcessed, "{\"instructedamountcurrency\":\"INCOMING_PAYMENT_PROCESSED\"}")]
     [InlineData(TestEnum.Unknown, "{\"instructedamountcurrency\":\"Unknown\"}")]

--- a/test/MoneyMoov.UnitTests/Json/EnumConverterTests.cs
+++ b/test/MoneyMoov.UnitTests/Json/EnumConverterTests.cs
@@ -31,6 +31,11 @@ public class EnumConverterTests
         IncomingPaymentProcessed = 1
     }
 
+    private class TestClass
+    {
+        public TestEnum? Instructedamountcurrency { get; set; }
+    }
+
     [Theory]
     [InlineData("\"INT_INTERC\"", TestEnum.INTINTERC)]
     [InlineData("\"INCOMING_PAYMENT_PROCESSED\"", TestEnum.IncomingPaymentProcessed)]
@@ -51,5 +56,31 @@ public class EnumConverterTests
     {
         var json = enumValue.ToJsonFlat();
         Assert.Equal($"\"{expected}\"", json);
+    }
+
+    [Theory]
+    [InlineData("{\"Instructedamountcurrency\":\"\"}", null)]
+    [InlineData("{\"Instructedamountcurrency\":\"INT_INTERC\"}", TestEnum.INTINTERC)]
+    [InlineData("{\"Instructedamountcurrency\":\"INCOMING_PAYMENT_PROCESSED\"}", TestEnum.IncomingPaymentProcessed)]
+    [InlineData("{\"Instructedamountcurrency\":\"Unknown\"}", TestEnum.Unknown)]
+    [InlineData("{\"Instructedamountcurrency\":16}", TestEnum.INTINTERC)]
+    [InlineData("{\"Instructedamountcurrency\":1}", TestEnum.IncomingPaymentProcessed)]
+    public void Deserialise_NullableEnum_Success(string json, TestEnum? expected)
+    {
+        var result = json.FromJson<TestClass>();
+        Assert.NotNull(result);
+        Assert.Equal(expected, result.Instructedamountcurrency);
+    }
+
+    [Theory]
+    [InlineData(null, "{\"instructedamountcurrency\":null}")]
+    [InlineData(TestEnum.INTINTERC, "{\"instructedamountcurrency\":\"INT_INTERC\"}")]
+    [InlineData(TestEnum.IncomingPaymentProcessed, "{\"instructedamountcurrency\":\"INCOMING_PAYMENT_PROCESSED\"}")]
+    [InlineData(TestEnum.Unknown, "{\"instructedamountcurrency\":\"Unknown\"}")]
+    public void Serialise_NullableEnum_Success(TestEnum? enumValue, string expected)
+    {
+        var myClass = new TestClass { Instructedamountcurrency = enumValue };
+        var json = myClass.ToJsonFlat();
+        Assert.Equal(expected, json);
     }
 }

--- a/test/MoneyMoov.UnitTests/Json/NumericConverterTests.cs
+++ b/test/MoneyMoov.UnitTests/Json/NumericConverterTests.cs
@@ -1,0 +1,66 @@
+//-----------------------------------------------------------------------------
+// Filename:NumericConverterTests.cs
+//
+// Description: Unit tests for the MoneyMoov Json numeric converter class.
+//
+// Author(s):
+// Aaron Clauson (aaron@nofrixion.com)
+// 
+// History:
+// 09 Jun 2024  Aaron Clauson   Created, Stillorgan Wood, Dublin, Ireland.
+//
+// License:  
+// MIT.
+//-----------------------------------------------------------------------------
+
+using Xunit;
+
+namespace NoFrixion.MoneyMoov.UnitTests.Json;
+
+public class NumericConverterTests
+{
+    [Theory]
+    [InlineData("123", 123)]
+    [InlineData("\"123\"", 123)]
+    public void Deserialise_Int_Success(string json, int expected)
+    {
+        var result = json.FromJson<int>();
+        Assert.Equal(expected, result);
+    }
+
+    [Theory]
+    [InlineData("1234567890123", 1234567890123L)]
+    [InlineData("\"1234567890123\"", 1234567890123L)]
+    public void Deserialise_Long_Success(string json, long expected)
+    {
+        var result = json.FromJson<long>();
+        Assert.Equal(expected, result);
+    }
+
+    [Theory]
+    [InlineData("123.45", 123.45f)]
+    [InlineData("\"123.45\"", 123.45f)]
+    public void Deserialise_Float_Success(string json, float expected)
+    {
+        var result = json.FromJson<float>();
+        Assert.Equal(expected, result);
+    }
+
+    [Theory]
+    [InlineData("123.456789", 123.456789)]
+    [InlineData("\"123.456789\"", 123.456789)]
+    public void Deserialise_Double_Success(string json, double expected)
+    {
+        var result = json.FromJson<double>();
+        Assert.Equal(expected, result);
+    }
+
+    [Theory]
+    [InlineData("123456.789", 123456.789)]
+    [InlineData("\"123456.789\"", 123456.789)]
+    public void Deserialise_Decimal_Success(string json, decimal expected)
+    {
+        var result = json.FromJson<decimal>();
+        Assert.Equal(expected, result);
+    }
+}

--- a/test/MoneyMoov.UnitTests/Json/NumericConverterTests.cs
+++ b/test/MoneyMoov.UnitTests/Json/NumericConverterTests.cs
@@ -20,47 +20,62 @@ namespace NoFrixion.MoneyMoov.UnitTests.Json;
 public class NumericConverterTests
 {
     [Theory]
-    [InlineData("123", 123)]
-    [InlineData("\"123\"", 123)]
-    public void Deserialise_Int_Success(string json, int expected)
+    [InlineData("\"42\"", 42)]
+    [InlineData("42", 42)]
+    [InlineData("\"\"", 0)]
+    [InlineData("null", 0)]
+    public void Deserialize_Int_Success(string json, int expected)
     {
         var result = json.FromJson<int>();
         Assert.Equal(expected, result);
     }
 
     [Theory]
-    [InlineData("1234567890123", 1234567890123L)]
-    [InlineData("\"1234567890123\"", 1234567890123L)]
-    public void Deserialise_Long_Success(string json, long expected)
-    {
-        var result = json.FromJson<long>();
-        Assert.Equal(expected, result);
-    }
-
-    [Theory]
-    [InlineData("123.45", 123.45f)]
-    [InlineData("\"123.45\"", 123.45f)]
-    public void Deserialise_Float_Success(string json, float expected)
-    {
-        var result = json.FromJson<float>();
-        Assert.Equal(expected, result);
-    }
-
-    [Theory]
-    [InlineData("123.456789", 123.456789)]
-    [InlineData("\"123.456789\"", 123.456789)]
-    public void Deserialise_Double_Success(string json, double expected)
+    [InlineData("\"42.42\"", 42.42)]
+    [InlineData("42.42", 42.42)]
+    [InlineData("\"\"", 0.0)]
+    [InlineData("null", 0.0)]
+    public void Deserialize_Double_Success(string json, double expected)
     {
         var result = json.FromJson<double>();
         Assert.Equal(expected, result);
     }
 
     [Theory]
-    [InlineData("123456.789", 123456.789)]
-    [InlineData("\"123456.789\"", 123456.789)]
-    public void Deserialise_Decimal_Success(string json, decimal expected)
+    [InlineData("\"42.42\"", 42.42)]
+    [InlineData("42.42", 42.42)]
+    [InlineData("\"\"", 0.0)]
+    [InlineData("null", 0.0)]
+    public void Deserialize_Decimal_Success(string json, decimal expected)
     {
         var result = json.FromJson<decimal>();
         Assert.Equal(expected, result);
+    }
+
+    [Theory]
+    [InlineData(42, "42")]
+    [InlineData(0, "0")]
+    public void Serialize_Int_Success(int value, string expected)
+    {
+        var json = value.ToJsonFlat();
+        Assert.Equal(expected, json);
+    }
+
+    [Theory]
+    [InlineData(42.42, "42.42")]
+    [InlineData(0.0, "0")]
+    public void Serialize_Double_Success(double value, string expected)
+    {
+        var json = value.ToJsonFlat();
+        Assert.Equal(expected, json);
+    }
+
+    [Theory]
+    [InlineData(42.42, "42.42")]
+    [InlineData(0.0, "0")]
+    public void Serialize_Decimal_Success(decimal value, string expected)
+    {
+        var json = value.ToJsonFlat();
+        Assert.Equal(expected, json);
     }
 }

--- a/test/MoneyMoov.UnitTests/Json/NumericConverterTests.cs
+++ b/test/MoneyMoov.UnitTests/Json/NumericConverterTests.cs
@@ -23,7 +23,7 @@ public class NumericConverterTests
     [InlineData("\"42\"", 42)]
     [InlineData("42", 42)]
     [InlineData("\"\"", 0)]
-    [InlineData("null", 0)]
+    //[InlineData("null", 0)]
     public void Deserialize_Int_Success(string json, int expected)
     {
         var result = json.FromJson<int>();
@@ -34,7 +34,7 @@ public class NumericConverterTests
     [InlineData("\"42.42\"", 42.42)]
     [InlineData("42.42", 42.42)]
     [InlineData("\"\"", 0.0)]
-    [InlineData("null", 0.0)]
+    //[InlineData("null", 0.0)]
     public void Deserialize_Double_Success(string json, double expected)
     {
         var result = json.FromJson<double>();
@@ -45,7 +45,7 @@ public class NumericConverterTests
     [InlineData("\"42.42\"", 42.42)]
     [InlineData("42.42", 42.42)]
     [InlineData("\"\"", 0.0)]
-    [InlineData("null", 0.0)]
+    //[InlineData("null", 0.0)]
     public void Deserialize_Decimal_Success(string json, decimal expected)
     {
         var result = json.FromJson<decimal>();

--- a/test/MoneyMoov.UnitTests/Json/NumericConverterTests.cs
+++ b/test/MoneyMoov.UnitTests/Json/NumericConverterTests.cs
@@ -22,8 +22,6 @@ public class NumericConverterTests
     [Theory]
     [InlineData("\"42\"", 42)]
     [InlineData("42", 42)]
-    [InlineData("\"\"", 0)]
-    //[InlineData("null", 0)]
     public void Deserialize_Int_Success(string json, int expected)
     {
         var result = json.FromJson<int>();
@@ -33,8 +31,6 @@ public class NumericConverterTests
     [Theory]
     [InlineData("\"42.42\"", 42.42)]
     [InlineData("42.42", 42.42)]
-    [InlineData("\"\"", 0.0)]
-    //[InlineData("null", 0.0)]
     public void Deserialize_Double_Success(string json, double expected)
     {
         var result = json.FromJson<double>();
@@ -44,8 +40,6 @@ public class NumericConverterTests
     [Theory]
     [InlineData("\"42.42\"", 42.42)]
     [InlineData("42.42", 42.42)]
-    [InlineData("\"\"", 0.0)]
-    //[InlineData("null", 0.0)]
     public void Deserialize_Decimal_Success(string json, decimal expected)
     {
         var result = json.FromJson<decimal>();
@@ -63,7 +57,7 @@ public class NumericConverterTests
 
     [Theory]
     [InlineData(42.42, "42.42")]
-    [InlineData(0.0, "0")]
+    [InlineData(0.0, "0.0")]
     public void Serialize_Double_Success(double value, string expected)
     {
         var json = value.ToJsonFlat();
@@ -72,10 +66,45 @@ public class NumericConverterTests
 
     [Theory]
     [InlineData(42.42, "42.42")]
-    [InlineData(0.0, "0")]
+    [InlineData(0.0, "0.0")]
     public void Serialize_Decimal_Success(decimal value, string expected)
     {
         var json = value.ToJsonFlat();
         Assert.Equal(expected, json);
+    }
+
+    [Fact]
+    public void Deserialize_Empty_Int_Exception()
+    {
+        string json = "\"\"";
+        Assert.Throws<Newtonsoft.Json.JsonSerializationException>(() => json.FromJson<int>());
+    }
+
+    [Fact]
+    public void Deserialize_Empty_Decimal_Exception()
+    {
+        string json = "\"\"";
+        Assert.Throws<Newtonsoft.Json.JsonSerializationException>(() => json.FromJson<decimal>());
+    }
+
+    [Fact]
+    public void Deserialize_Empty_Float_Exception()
+    {
+        string json = "\"\"";
+        Assert.Throws<Newtonsoft.Json.JsonSerializationException>(() => json.FromJson<float>());
+    }
+
+    [Fact]
+    public void Deserialize_Empty_Double_Exception()
+    {
+        string json = "\"\"";
+        Assert.Throws<Newtonsoft.Json.JsonSerializationException>(() => json.FromJson<double>());
+    }
+
+    [Fact]
+    public void Deserialize_Empty_Long_Exception()
+    {
+        string json = "\"\"";
+        Assert.Throws<Newtonsoft.Json.JsonSerializationException>(() => json.FromJson<long>());
     }
 }

--- a/test/MoneyMoov.UnitTests/Models/BeneficiarySerialisationTests.cs
+++ b/test/MoneyMoov.UnitTests/Models/BeneficiarySerialisationTests.cs
@@ -16,8 +16,6 @@
 
 using Microsoft.Extensions.Logging;
 using NoFrixion.MoneyMoov.Models;
-using System.Text.Json;
-using System.Text.Json.Serialization;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -56,10 +54,8 @@ public class BeneficiarySerialisationTests : MoneyMoovUnitTestBase<BeneficiarySe
                 }}  
             }";
 
-        var options = new JsonSerializerOptions() { PropertyNameCaseInsensitive = true };
-        options.Converters.Add(new JsonStringEnumConverter());
-        var beneficiary = System.Text.Json.JsonSerializer.Deserialize<Beneficiary>(beneficiaryJson, options);
-        
+        var beneficiary = beneficiaryJson.FromJson<Beneficiary>();
+
         Assert.NotNull(beneficiary);
         Assert.NotNull(beneficiary?.Destination);
         Assert.NotNull(beneficiary?.Destination?.Identifier);

--- a/test/MoneyMoov.UnitTests/Models/BeneficiarySerialisationTests.cs
+++ b/test/MoneyMoov.UnitTests/Models/BeneficiarySerialisationTests.cs
@@ -30,54 +30,6 @@ public class BeneficiarySerialisationTests : MoneyMoovUnitTestBase<BeneficiarySe
 
     /// <summary>
     /// Tests that a beneficiary can be deserialised from its JSON represnetation
-    /// using Newtonsoft.
-    /// </summary>
-    [Fact]
-    public void Deserialise_Newtonsoft_Beneficiary_Test()
-    {
-        Logger.LogDebug($"--> {TypeExtensions.GetCaller()}.");
-
-        var beneficiaryJson = @"
-            {
-                ""id"":""1e92214c-1650-49c4-760c-08db1746a020"",
-                ""merchantID"":""2186d737-50a1-48b0-a7e7-7f39cb40407e"",
-                ""name"":""Test Beneficiary"",
-                ""yourReference"":""YourRef"",
-                ""theirReference"":""TheirRef"",
-                ""currency"":""EUR"",
-                ""destination"": {
-                    ""name"":""Destination account"",
-                    ""identifier"":{
-                        ""type"":""IBAN"",
-                        ""iban"":""GB33BUKB20201555555555"",
-                        ""summary"":""IBAN: GB33BUKB20201555555555""
-                }}
-            }";
-
-        var beneficiary = Newtonsoft.Json.JsonConvert.DeserializeObject<Beneficiary>(beneficiaryJson);
-
-        //var rule = Newtonsoft.Json.JsonConvert.DeserializeObject<Rule>(sweepRuleJson, settings: new JsonSerializerSettings
-        //{
-        //    ObjectCreationHandling = ObjectCreationHandling.Replace,
-        //});
-
-        //var options = new JsonSerializerOptions();
-        //options.Converters.Add(new JsonStringEnumConverter());
-        //var rule = await response.Content.ReadFromJsonAsync<Rule>(options);
-
-        Assert.NotNull(beneficiary);
-        Assert.NotNull(beneficiary?.Destination);
-        Assert.NotNull(beneficiary?.Destination?.Identifier);
-        Assert.Equal("1e92214c-1650-49c4-760c-08db1746a020", beneficiary?.ID.ToString());
-        Assert.Equal("2186d737-50a1-48b0-a7e7-7f39cb40407e", beneficiary?.MerchantID.ToString());
-        Assert.Equal("Test Beneficiary", beneficiary?.Name);
-        Assert.Equal("Destination account", beneficiary?.Destination?.Name);
-        Assert.Equal(AccountIdentifierType.IBAN, beneficiary?.Destination?.Identifier?.Type);
-        Assert.Equal("GB33BUKB20201555555555", beneficiary?.Destination?.Identifier?.IBAN);
-    }
-
-    /// <summary>
-    /// Tests that a beneficiary can be deserialised from its JSON represnetation
     /// using System.Text.
     /// </summary>
     [Fact]

--- a/test/MoneyMoov.UnitTests/Models/BeneficiaryValidationTests.cs
+++ b/test/MoneyMoov.UnitTests/Models/BeneficiaryValidationTests.cs
@@ -17,6 +17,7 @@ using Microsoft.Extensions.Logging;
 using NoFrixion.MoneyMoov.Models;
 using Xunit;
 using Xunit.Abstractions;
+using System.Text.Json;
 
 namespace NoFrixion.MoneyMoov.UnitTests;
 
@@ -73,7 +74,7 @@ public class BeneficairyValidationTests : MoneyMoovUnitTestBase<BeneficairyValid
 
         foreach (var err in problem.Errors)
         {
-            Logger.LogDebug(Newtonsoft.Json.JsonConvert.SerializeObject(err));
+            Logger.LogDebug(JsonSerializer.Serialize(err));
         }
 
         Assert.NotEmpty(problem.Errors);

--- a/test/MoneyMoov.UnitTests/Models/BeneficiaryValidationTests.cs
+++ b/test/MoneyMoov.UnitTests/Models/BeneficiaryValidationTests.cs
@@ -74,7 +74,7 @@ public class BeneficairyValidationTests : MoneyMoovUnitTestBase<BeneficairyValid
 
         foreach (var err in problem.Errors)
         {
-            Logger.LogDebug(JsonSerializer.Serialize(err));
+            Logger.LogDebug(err.ToJsonFormatted());
         }
 
         Assert.NotEmpty(problem.Errors);

--- a/test/MoneyMoov.UnitTests/Models/PaymentRequestMetricsTests.cs
+++ b/test/MoneyMoov.UnitTests/Models/PaymentRequestMetricsTests.cs
@@ -14,7 +14,7 @@
 //-----------------------------------------------------------------------------
 
 using Microsoft.Extensions.Logging;
-using Newtonsoft.Json;
+using System.Text.Json;
 using NoFrixion.MoneyMoov.Models;
 using Xunit;
 using Xunit.Abstractions;
@@ -36,7 +36,7 @@ public class PaymentRequestMetricsTests : MoneyMoovUnitTestBase<PaymentRequestMe
 
         string metricsJson = " {\"all\":10,\"unpaid\":1,\"partiallyPaid\":3,\"paid\":2,\"authorized\":4,\"totalAmountsByCurrency\":{\"all\":{\"eur\":329.01000000000},\"paid\":{\"eur\":103.00000000000},\"unpaid\":{\"eur\":100.00000000000},\"partiallyPaid\":{\"eur\":101.00000000000},\"authorized\":{\"eur\":0.01000000000}}}";
 
-        var metrics = JsonConvert.DeserializeObject<PaymentRequestMetrics>(metricsJson);
+        var metrics = JsonSerializer.Deserialize<PaymentRequestMetrics>(metricsJson);
 
         Assert.NotNull(metrics);
 

--- a/test/MoneyMoov.UnitTests/Models/PaymentRequestMetricsTests.cs
+++ b/test/MoneyMoov.UnitTests/Models/PaymentRequestMetricsTests.cs
@@ -14,7 +14,6 @@
 //-----------------------------------------------------------------------------
 
 using Microsoft.Extensions.Logging;
-using System.Text.Json;
 using NoFrixion.MoneyMoov.Models;
 using Xunit;
 using Xunit.Abstractions;
@@ -36,7 +35,7 @@ public class PaymentRequestMetricsTests : MoneyMoovUnitTestBase<PaymentRequestMe
 
         string metricsJson = " {\"all\":10,\"unpaid\":1,\"partiallyPaid\":3,\"paid\":2,\"authorized\":4,\"totalAmountsByCurrency\":{\"all\":{\"eur\":329.01000000000},\"paid\":{\"eur\":103.00000000000},\"unpaid\":{\"eur\":100.00000000000},\"partiallyPaid\":{\"eur\":101.00000000000},\"authorized\":{\"eur\":0.01000000000}}}";
 
-        var metrics = JsonSerializer.Deserialize<PaymentRequestMetrics>(metricsJson);
+        var metrics = metricsJson.FromJson<PaymentRequestMetrics>();
 
         Assert.NotNull(metrics);
 

--- a/test/MoneyMoov.UnitTests/Models/RuleSerialisationTests.cs
+++ b/test/MoneyMoov.UnitTests/Models/RuleSerialisationTests.cs
@@ -17,8 +17,6 @@
 using Microsoft.Extensions.Logging;
 using NoFrixion.Biz.BizModels.Paging;
 using NoFrixion.MoneyMoov.Models;
-using System.Text.Json;
-using System.Text.Json.Serialization;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -70,9 +68,7 @@ public class RuleSerialisationTests : MoneyMoovUnitTestBase<RuleSerialisationTes
               ""lastUpdated"": ""2023-01-25T20:09:44.1118082+00:00""
             }";
 
-        var options = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
-        options.Converters.Add(new JsonStringEnumConverter());
-        var rule = System.Text.Json.JsonSerializer.Deserialize<Rule>(sweepRuleJson, options);
+        var rule = sweepRuleJson.FromJson<Rule>();
 
         Assert.NotNull(rule);
         Assert.NotNull(rule.SweepAction);
@@ -133,9 +129,7 @@ public class RuleSerialisationTests : MoneyMoovUnitTestBase<RuleSerialisationTes
               ""lastUpdated"": ""2023-01-25T20:09:44.1118082+00:00""
             }";
 
-        var options = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
-        options.Converters.Add(new JsonStringEnumConverter());
-        var rule = JsonSerializer.Deserialize<Rule>(sweepRuleJson, options);
+        var rule = sweepRuleJson.FromJson<Rule>();
 
         Assert.NotNull(rule);
         Assert.NotNull(rule.SweepAction);
@@ -245,12 +239,7 @@ public class RuleSerialisationTests : MoneyMoovUnitTestBase<RuleSerialisationTes
   ""totalSize"": 1
 }";
 
-        var rules = JsonSerializer.Deserialize<RulesPageResponse>(rulesJson, 
-            new JsonSerializerOptions
-            {
-                PropertyNameCaseInsensitive = true,
-                Converters = { new JsonStringEnumConverter() }
-            });
+        var rules = rulesJson.FromJson<RulesPageResponse>();
 
         Assert.NotNull(rules);
         Assert.NotNull(rules.Content);

--- a/test/MoneyMoov.UnitTests/Models/RuleSerialisationTests.cs
+++ b/test/MoneyMoov.UnitTests/Models/RuleSerialisationTests.cs
@@ -33,60 +33,7 @@ public class RuleSerialisationTests : MoneyMoovUnitTestBase<RuleSerialisationTes
     /// Tests that a sweep rule can be deserialised from a JSON representation.
     /// </summary>
     [Fact]
-    public void Deserialise_Newtonsoft_Sweep_Rule_Test()
-    {
-        Logger.LogDebug($"--> {TypeExtensions.GetCaller()}.");
-
-        var sweepRuleJson = @"
-            {
-              ""id"": ""60dd3c00-22bb-4a30-07f6-08daff10193e"",
-              ""accountID"": ""fe37ca97-be54-4a8a-9745-07667adcd9ba"",
-              ""userID"": ""8ce4c97c-ccfe-4776-8903-dae7ed1f7ca6"",
-              ""name"": ""Test Sweep Rule Create"",
-              ""isEnabled"": false,
-              ""status"": ""PendingApproval"",
-              ""triggerOnPayIn"": false,
-              ""triggerOnPayOut"": false,
-              ""sweepAction"": {
-                ""priority"": 1,
-                ""actionType"": ""Sweep"",
-                ""destinations"": [
-                  {
-                    ""sweepPercentage"": 100,
-                    ""sweepAmount"": 0,
-                    ""name"": ""Jane Doe"",
-                    ""identifier"": {
-                      ""type"": ""IBAN"",
-                      ""currency"": ""EUR"",
-                      ""iban"": ""IEMOCK123456779"",
-                      ""summary"": ""IBAN: IEMOCK123456779""
-                    },
-                    ""summary"": ""Jane Doe, IBAN: IEMOCK123456779""
-                  }
-                ],
-                ""amountToLeave"": 1
-              },
-              ""inserted"": ""2023-01-25T20:09:44.1113893+00:00"",
-              ""lastUpdated"": ""2023-01-25T20:09:44.1118082+00:00""
-            }";
-
-        var rule = Newtonsoft.Json.JsonConvert.DeserializeObject<Rule>(sweepRuleJson);
-
-        Assert.NotNull(rule);
-        Assert.NotNull(rule.SweepAction);
-        Assert.NotNull(rule.SweepAction.Destinations);
-        Assert.Single(rule.SweepAction.Destinations);
-        Assert.Equal(RuleStatusEnum.PendingApproval, rule?.Status);
-        Assert.Null(rule?.SweepAction?.PayoutYourReference);
-        Assert.Null(rule?.SweepAction?.PayoutTheirReference);
-        Assert.Null(rule?.SweepAction?.PayoutDescription);
-    }
-
-    /// <summary>
-    /// Tests that a sweep rule can be deserialised from a JSON representation.
-    /// </summary>
-    [Fact]
-    public void Deserialise_SystemJson_Sweep_Rule_Test()
+    public void Deserialise_Json_Sweep_Rule_Test()
     {
         Logger.LogDebug($"--> {TypeExtensions.GetCaller()}.");
 
@@ -188,7 +135,7 @@ public class RuleSerialisationTests : MoneyMoovUnitTestBase<RuleSerialisationTes
 
         var options = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
         options.Converters.Add(new JsonStringEnumConverter());
-        var rule = System.Text.Json.JsonSerializer.Deserialize<Rule>(sweepRuleJson, options);
+        var rule = JsonSerializer.Deserialize<Rule>(sweepRuleJson, options);
 
         Assert.NotNull(rule);
         Assert.NotNull(rule.SweepAction);
@@ -298,7 +245,7 @@ public class RuleSerialisationTests : MoneyMoovUnitTestBase<RuleSerialisationTes
   ""totalSize"": 1
 }";
 
-        var rules = System.Text.Json.JsonSerializer.Deserialize<RulesPageResponse>(rulesJson, 
+        var rules = JsonSerializer.Deserialize<RulesPageResponse>(rulesJson, 
             new JsonSerializerOptions
             {
                 PropertyNameCaseInsensitive = true,
@@ -317,6 +264,5 @@ public class RuleSerialisationTests : MoneyMoovUnitTestBase<RuleSerialisationTes
         Assert.Equal(CurrencyTypeEnum.EUR, rules?.Content[0].SweepAction.Destinations[0]?.Identifier?.Currency);
         Assert.Equal("IEMOCK123456779", rules?.Content[0].SweepAction.Destinations[0]?.Identifier?.IBAN);
         Assert.Equal(1.0M, rules?.Content[0].SweepAction.AmountToLeave);
-
     }
 }

--- a/test/MoneyMoov.UnitTests/Models/RuleValidationTests.cs
+++ b/test/MoneyMoov.UnitTests/Models/RuleValidationTests.cs
@@ -17,6 +17,7 @@ using Microsoft.Extensions.Logging;
 using NoFrixion.MoneyMoov.Models;
 using Xunit;
 using Xunit.Abstractions;
+using System.Text.Json;
 
 namespace NoFrixion.MoneyMoov.UnitTests;
 
@@ -63,7 +64,7 @@ public class RuleValidationTests : MoneyMoovUnitTestBase<RuleValidationTests>
 
         foreach (var err in problem.Errors)
         {
-            Logger.LogDebug(Newtonsoft.Json.JsonConvert.SerializeObject(err));
+            Logger.LogDebug(JsonSerializer.Serialize(err));
         }
 
         Assert.Equal(problem.Errors.Count == 0, shouldSucceed);

--- a/test/MoneyMoov.UnitTests/Models/RuleValidationTests.cs
+++ b/test/MoneyMoov.UnitTests/Models/RuleValidationTests.cs
@@ -17,7 +17,6 @@ using Microsoft.Extensions.Logging;
 using NoFrixion.MoneyMoov.Models;
 using Xunit;
 using Xunit.Abstractions;
-using System.Text.Json;
 
 namespace NoFrixion.MoneyMoov.UnitTests;
 
@@ -64,7 +63,7 @@ public class RuleValidationTests : MoneyMoovUnitTestBase<RuleValidationTests>
 
         foreach (var err in problem.Errors)
         {
-            Logger.LogDebug(JsonSerializer.Serialize(err));
+            Logger.LogDebug(err.ToJsonFormatted());
         }
 
         Assert.Equal(problem.Errors.Count == 0, shouldSucceed);

--- a/test/MoneyMoov.UnitTests/Models/TransactionSerialisationTests.cs
+++ b/test/MoneyMoov.UnitTests/Models/TransactionSerialisationTests.cs
@@ -16,8 +16,6 @@
 
 using Microsoft.Extensions.Logging;
 using NoFrixion.MoneyMoov.Models;
-using System.Text.Json;
-using System.Text.Json.Serialization;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -38,9 +36,7 @@ public class TransactionSerialisationTests : MoneyMoovUnitTestBase<TransactionSe
 
         var tx = new Transaction();
 
-        var options = new JsonSerializerOptions { PropertyNameCaseInsensitive = true };
-        options.Converters.Add(new JsonStringEnumConverter());
-        var txJson = System.Text.Json.JsonSerializer.Serialize<Transaction>(tx, options);
+        var txJson = tx.ToJsonFlat();
 
         Assert.NotEmpty(txJson);
     }


### PR DESCRIPTION
Adds serialisation settings and methods for Newtonsoft and System.Text.Json as well as extension methods for serialisation and deserialisation.

A sections is being added to confluence to explain usage.

Note this PR doesn't actually remove newtonsoft. While that was the original intention it turns our it is more practical for our purposes.