### PR TITLE
MOOV-3289: Added BeneficiaryEnabled Payout event type

### DIFF
--- a/src/NoFrixion.MoneyMoov/Enums/PayoutEventTypesEnum.cs
+++ b/src/NoFrixion.MoneyMoov/Enums/PayoutEventTypesEnum.cs
@@ -91,5 +91,10 @@ public enum PayoutEventTypesEnum
     /// <summary>
     /// The payout has been signed.
     /// </summary>
-    Signed = 14
+    Signed = 14,
+        
+    /// <summary>
+    /// A payout's associated beneficiary was enabled.
+    /// </summary>
+    BeneficiaryEnabled = 15,
 }


### PR DESCRIPTION
Added a payout event type for recording when a payout's beneficiary is enabled. Kind of an infrequent occurrence, but just in case.