### PR TITLE
MOOV-3176: Invoice Reference field is no longer required

### DIFF
--- a/src/NoFrixion.MoneyMoov/Models/Payruns/PayrunInvoice.cs
+++ b/src/NoFrixion.MoneyMoov/Models/Payruns/PayrunInvoice.cs
@@ -28,8 +28,7 @@ public class PayrunInvoice : IValidatableObject
     
     [Obsolete("Please use Reference instead.")]
     public string? InvoiceNumber { get; set; }
-
-    [Required]
+    
     public required string Reference { get; set; }
 
     public string? PaymentTerms { get; set; }


### PR DESCRIPTION
Drops the Required requirement (lol) for the Payrun Invoice Reference field.