### PR TITLE
Fixed issue with EF not able to find enum value.

### DIFF
--- a/src/NoFrixion.MoneyMoov/Enums/PayrunEventTypeEnum.cs
+++ b/src/NoFrixion.MoneyMoov/Enums/PayrunEventTypeEnum.cs
@@ -22,15 +22,17 @@ public enum PayrunEventTypeEnum
 
     Created = 1,
     
-    Submitted = 2,
+    Authorised = 2,
     
-    Rejected = 3,
+    Submitted = 3,
     
-    Edited = 4,
+    Rejected = 4,
     
-    AuthorisationRequested = 5,
+    Edited = 5,
     
-    Completed = 6,
+    AuthorisationRequested = 6,
     
-    Approved = 7,
+    Completed = 7,
+    
+    Approved = 8,
 }


### PR DESCRIPTION
Removing the Authorised event type from enum lead to issue in EF not able to find the enum value for existing payruns.