### PR TITLE
Add internal account name in counterparty

### DIFF
--- a/src/NoFrixion.MoneyMoov/Models/Transaction/Counterparty.cs
+++ b/src/NoFrixion.MoneyMoov/Models/Transaction/Counterparty.cs
@@ -27,6 +27,11 @@ public class Counterparty
     /// it will take precedence over any other destination details set for the counterparty.
     /// </summary>
     public Guid? AccountID { get; set; }
+    
+    /// <summary>
+    /// If the counterparty is an internal account, this is the name of the account.
+    /// </summary>
+    public string? InternalAccountName { get; set; } = string.Empty;
 
     /// <summary>
     /// Optional ID of a Beneficiary to use for the counterparty destination. If set


### PR DESCRIPTION
This PR is just to get a review of my proposed solution to be able to display internal account name in rules on UI. Currently, if the destination is an internal account, the counter party name is returned as the merchant name. Which makes sense as we use the merchant name to process the payment, the internal account name is just an alias for us. 

Here I am adding a new property in Counterparty called InternalAccountName which will be returned if the counter party is an internal account.