### PR TITLE
Remove invoice specific validaiton logic and use payout validations.

### DIFF
--- a/src/NoFrixion.MoneyMoov/Mapping/PayrunInvoiceMapper.cs
+++ b/src/NoFrixion.MoneyMoov/Mapping/PayrunInvoiceMapper.cs
@@ -1,0 +1,53 @@
+//-----------------------------------------------------------------------------
+// Filename: PayrunInvoiceMapper.cs
+//
+// Description: Payrun Invoice model mapper.
+// 
+// Author(s):
+// Aaron Clauson (aaron@nofrixion.com)
+// 
+// History:
+// 05 Jul 2024  Aaron Clauson   Created, Carne, Wexford, Ireland.
+// 
+// License:
+// MIT.
+//-----------------------------------------------------------------------------
+
+using Ardalis.GuardClauses;
+using NoFrixion.MoneyMoov.Models;
+
+namespace NoFrixion.MoneyMoov;
+
+public static class PayrunInvoiceMapper
+{
+    /// <summary>
+    /// A safe TheirReference value that will pass validation sofr all currencies and processors.
+    /// Payrun invoices result in an auto-generating TheirReference when teh Payout is ultimately
+    /// created.
+    /// </summary>
+    private const string SAFE_THEIR_REFERENCE = "Safe Reference";
+
+    public static Payout ToPayout(this PayrunInvoice invoice)
+    {
+        Guard.Against.Null(invoice, nameof(invoice));
+
+        return new Payout
+        {
+            Currency = invoice.Currency,
+            Type = invoice.Currency == CurrencyTypeEnum.GBP ? AccountIdentifierType.SCAN : AccountIdentifierType.IBAN,
+            Amount = invoice.TotalAmount,
+            TheirReference = SAFE_THEIR_REFERENCE,
+            Destination = new Counterparty
+            {
+                Name = invoice.DestinationAccountName,
+                Identifier = new AccountIdentifier 
+                { 
+                    Currency = invoice.Currency,
+                    IBAN = invoice.DestinationIban,
+                    SortCode = invoice.DestinationSortCode,
+                    AccountNumber = invoice.DestinationAccountNumber
+                },
+            }
+        };
+    }
+}

--- a/src/NoFrixion.MoneyMoov/Models/Payouts/PayoutsValidator.cs
+++ b/src/NoFrixion.MoneyMoov/Models/Payouts/PayoutsValidator.cs
@@ -189,7 +189,11 @@ public static class PayoutsValidator
         return processor switch
         {
             PaymentProcessorsEnum.Modulr => ValidateModulrAccountName(accountName),
-            _ => ValidateBankingCircleStringField(accountName, ACCOUNT_NAME_MAXIMUM_BANKING_CIRCLE_LENGTH)
+            PaymentProcessorsEnum.BankingCircle => ValidateBankingCircleStringField(accountName, ACCOUNT_NAME_MAXIMUM_BANKING_CIRCLE_LENGTH),
+            PaymentProcessorsEnum.BankingCircleAgency => ValidateBankingCircleStringField(accountName, ACCOUNT_NAME_MAXIMUM_BANKING_CIRCLE_LENGTH),
+            // If the payment processor is not known, or has no specific validations, perform all the validations.
+            _ => ValidateModulrAccountName(accountName) &&
+                ValidateBankingCircleStringField(accountName, ACCOUNT_NAME_MAXIMUM_BANKING_CIRCLE_LENGTH)
         };
     }
 
@@ -206,7 +210,11 @@ public static class PayoutsValidator
         return processor switch
         {
             PaymentProcessorsEnum.Modulr => ValidateModulrTheirReference(theirReference, desinationIdentifierType),
-            _ => ValidateBankingCircleStringField(theirReference, REFERENCE_MAXIMUM_BANKING_CIRCLE_LENGTH),
+            PaymentProcessorsEnum.BankingCircle => ValidateBankingCircleStringField(theirReference, REFERENCE_MAXIMUM_BANKING_CIRCLE_LENGTH),
+            PaymentProcessorsEnum.BankingCircleAgency => ValidateBankingCircleStringField(theirReference, REFERENCE_MAXIMUM_BANKING_CIRCLE_LENGTH),
+            // If the payment processor is not known, or has no specific validations, perform all the validations.
+            _ => ValidateModulrTheirReference(theirReference, desinationIdentifierType) &&
+                ValidateBankingCircleStringField(theirReference, REFERENCE_MAXIMUM_BANKING_CIRCLE_LENGTH),
         };
     }
 

--- a/src/NoFrixion.MoneyMoov/Models/Payruns/PayrunInvoice.cs
+++ b/src/NoFrixion.MoneyMoov/Models/Payruns/PayrunInvoice.cs
@@ -70,52 +70,10 @@ public class PayrunInvoice : IValidatableObject
     public IEnumerable<InvoicePayment>? InvoicePayments { get; set; }
     
     public bool IsEnabled { get; set; }
-    
+
+    public NoFrixionProblem Validate()
+        => this.ToPayout().Validate();
+
     public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)
-    {
-        if (TotalAmount <= decimal.Zero)
-        {
-            yield return new ValidationResult("The TotalAmount must be more than 0.", new string[] { nameof(TotalAmount) });
-        }
-
-        if (string.IsNullOrEmpty(DestinationIban) && string.IsNullOrEmpty(DestinationAccountNumber))
-        {
-            yield return new ValidationResult("The DestinationIban or DestinationAccountNumber must be provided.", new string[] { nameof(DestinationIban), nameof(DestinationAccountNumber) });
-        }
-        
-        if (!string.IsNullOrEmpty(DestinationIban) && !string.IsNullOrEmpty(DestinationAccountNumber))
-        {
-            yield return new ValidationResult("The DestinationIban and DestinationAccountNumber cannot both be provided.", new string[] { nameof(DestinationIban), nameof(DestinationAccountNumber) });
-        }
-        
-        if (!string.IsNullOrEmpty(DestinationIban) && !PayoutsValidator.ValidateIBAN(DestinationIban))
-        {
-            yield return new ValidationResult("The DestinationIban must be a valid IBAN.", new string[] { nameof(DestinationIban) });
-        }
-        
-        if (!string.IsNullOrEmpty(DestinationAccountNumber) && string.IsNullOrEmpty(DestinationSortCode))
-        {
-            yield return new ValidationResult("DestinationSortCode must be provided if DestinationAccountNumber is set.", new string[] { nameof(DestinationSortCode) });
-        }
-        
-        if (!string.IsNullOrEmpty(DestinationSortCode) && string.IsNullOrEmpty(DestinationAccountNumber))
-        {
-            yield return new ValidationResult("DestinationAccountNumber must be provided if DestinationSortCode is set.", new string[] { nameof(DestinationSortCode) });
-        }
-        
-        if (!string.IsNullOrEmpty(DestinationIban) && Currency != CurrencyTypeEnum.EUR)
-        {
-            yield return new ValidationResult("DestinationIban can only be set for EUR currency.", new string[] { nameof(DestinationIban) });
-        }
-        
-        if (!string.IsNullOrEmpty(DestinationSortCode) && !string.IsNullOrEmpty(DestinationAccountNumber) && Currency != CurrencyTypeEnum.GBP)
-        {
-            yield return new ValidationResult("DestinationSortCode and DestinationAccountNumber can only be set for GBP currency.", new string[] { nameof(DestinationSortCode), nameof(DestinationAccountNumber) });
-        }
-
-        if (!PayoutsValidator.IsValidAccountName(DestinationAccountName ?? string.Empty, PaymentProcessorsEnum.None))
-        {
-            yield return new ValidationResult("DestinationAccountName must be a valid account name.", new string[] { nameof(DestinationAccountName) });
-        }
-    }
+        => this.ToPayout().Validate(validationContext);
 }

--- a/test/MoneyMoov.UnitTests/Models/PayrunInvoiceValidatorTests.cs
+++ b/test/MoneyMoov.UnitTests/Models/PayrunInvoiceValidatorTests.cs
@@ -1,0 +1,205 @@
+﻿//-----------------------------------------------------------------------------
+// Filename: PayrunInvoiceValidatorTests.cs
+//
+// Description: Unit tests for PayrunInvoice validation logic.
+//
+// Author(s):
+// Aaron Clauson (aaron@nofrixion.com)
+// 
+// History:
+// 05 Jul 2024  Aaron Clauson   Created, Carne, Wexford, Ireland.
+//
+// License: 
+// MIT.
+//-----------------------------------------------------------------------------
+
+using Microsoft.Extensions.Logging;
+using NoFrixion.MoneyMoov.Models;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace NoFrixion.MoneyMoov.UnitTests;
+
+public class PayrunInvoiceValidatorTests
+{
+    readonly ILogger<PayrunInvoiceValidatorTests> _logger;
+    private LoggerFactory _loggerFactory;
+
+    public PayrunInvoiceValidatorTests(ITestOutputHelper testOutputHelper)
+    {
+        _loggerFactory = new LoggerFactory();
+        _loggerFactory.AddProvider(new XunitLoggerProvider(testOutputHelper));
+        _logger = _loggerFactory.CreateLogger<PayrunInvoiceValidatorTests>();
+    }
+
+    /// <summary>
+    /// Tests that an invoice destination account Name is validated successfully. Note
+    /// because the payment procescor is generalyl not known when an invoice is being validated
+    /// the validation rules for all processor are applied.
+    /// </summary>
+    [Theory]
+    [InlineData("A")]
+    [InlineData("1-A")]
+    [InlineData("1-A-2-c")]
+    [InlineData("NFXN...LTD")]
+    public void Validate_Account_Name_Success(string accountName)
+    {
+        var payrunInvoice = new PayrunInvoice
+        { 
+            Reference = "ref-1", 
+            DestinationAccountName = accountName, 
+            Currency = CurrencyTypeEnum.EUR, 
+            TotalAmount = 11.00M,
+            DestinationIban = "IE83MOCK91012396989925"
+        };
+
+        var problem = payrunInvoice.Validate();
+
+        _logger.LogDebug(problem.ToJsonFormatted());
+
+        Assert.True(problem.IsEmpty);
+    }
+
+    /// <summary>
+    /// Tests that an invoice destination account Name is fails validation. Note
+    /// because the payment procescor is generalyl not known when an invoice is being validated
+    /// the validation rules for all processor are applied.
+    /// </summary>
+    [Theory]
+    [InlineData("/")] // No letter or number.
+    [InlineData("--")]// No letter or number.
+    [InlineData(".-/&")] // No letter or number.
+    [InlineData("1-A-2-c + + dfg")] // Invalid character '+'.
+    [InlineData("Big Bucks £")]// Invalid character '£'.
+    [InlineData("Big Bucks €")]// Invalid character '€'.
+    [InlineData(":")] // Invalid initial character, can't be ':' or '-'.
+    [InlineData("1-A-2-c + ! + dfg")] // Invalid character '!'.
+    [InlineData(".-/& a")] // BC don't support '&' in account name.
+    [InlineData("/:")] // BC don't support '/' in account name.
+    [InlineData("TELECOMUNICAÇÕES S.A.")] // BC don't support unicode.
+    [InlineData("Ç_é")] // BC don't support unicode.
+    [InlineData("NFXN: LTD")] // Modulr don't support ':'
+    public void Validate_Account_Name_Fails(string accountName)
+    {
+        var payrunInvoice = new PayrunInvoice
+        {
+            Reference = "ref-1",
+            DestinationAccountName = accountName,
+            Currency = CurrencyTypeEnum.EUR,
+            TotalAmount = 11.00M,
+            DestinationIban = "IE83MOCK91012396989925"
+        };
+
+        var problem = payrunInvoice.Validate();
+
+        _logger.LogDebug(problem.Detail);
+
+        Assert.False(problem.IsEmpty);
+    }
+
+    /// <summary>
+    /// Validates that an invoice with a valid IBAN passes validation.
+    /// </summary>
+    [Fact]
+    public void Validate_Payout_Valid_IBAN_Success()
+    {
+        var payrunInvoice = new PayrunInvoice
+        {
+            Reference = "ref-1",
+            DestinationAccountName = "Some Biz",
+            DestinationIban = "IE83MOCK91012396989925",
+            Currency = CurrencyTypeEnum.EUR,
+            TotalAmount = 11.00M
+        };
+
+        var result = payrunInvoice.Validate();
+
+        Assert.True(result.IsEmpty);
+    }
+
+    /// <summary>
+    /// Validates that an invoice with an invalid IBAN fails validation.
+    /// </summary>
+    [Fact]
+    public void Validate_Payout_Invalid_IBAN_Fails()
+    {
+        var payrunInvoice = new PayrunInvoice
+        {
+            Reference = "ref-1",
+            DestinationAccountName = "Some Biz",
+            DestinationIban = "IE36ULSB98501017331006",
+            Currency = CurrencyTypeEnum.EUR,
+            TotalAmount = 11.00M
+        };
+
+        var result = payrunInvoice.Validate();
+
+        _logger.LogDebug(result.ToTextErrorMessage());
+
+        Assert.False(result.IsEmpty);
+        Assert.Single(result.Errors);
+    }
+
+    /// <summary>
+    /// Validates that an invoice with a valid SCAN details passes validation.
+    /// </summary>
+    [Fact]
+    public void Validate_Payout_Valid_SCAN_Success()
+    {
+        var payrunInvoice = new PayrunInvoice
+        {
+            Reference = "ref-1",
+            DestinationAccountName = "Some Biz",
+            DestinationSortCode = "123456",
+            DestinationAccountNumber = "12345678",
+            Currency = CurrencyTypeEnum.GBP,
+            TotalAmount = 11.00M
+        };
+
+        var result = payrunInvoice.Validate();
+
+        Assert.True(result.IsEmpty);
+    }
+
+    /// <summary>
+    /// Tests than a EUR invoice mssing an IBAN fails validation.
+    /// </summary>
+    [Fact]
+    public void Invoice_Missing_IBAN_Failure()
+    {
+        var payrunInvoice = new PayrunInvoice
+        {
+            Reference = "ref-1",
+            DestinationAccountName = "Some Biz",
+            Currency = CurrencyTypeEnum.EUR,
+            TotalAmount = 11.00M
+        };
+
+        var result = payrunInvoice.Validate();
+        
+        _logger.LogDebug(result.ToJsonFormatted());
+        
+        Assert.False(result.IsEmpty);
+    }
+
+    /// <summary>
+    /// Tests than a GBP invoice mssing SCAN details fails validation.
+    /// </summary>
+    [Fact]
+    public void Invoice_Missing_SCAN_Failure()
+    {
+        var payrunInvoice = new PayrunInvoice
+        {
+            Reference = "ref-1",
+            DestinationAccountName = "Some Biz",
+            Currency = CurrencyTypeEnum.GBP,
+            TotalAmount = 11.00M
+        };
+
+        var result = payrunInvoice.Validate();
+
+        _logger.LogDebug(result.ToJsonFormatted());
+
+        Assert.False(result.IsEmpty);
+    }
+}


### PR DESCRIPTION
Will hopefully avoid the case where an invoice can result in a payout getting created but then fail once submitted to the upstream processor.