### PR TITLE
Prevent creating payouts on the same account

### DIFF
--- a/src/NoFrixion.MoneyMoov/Models/Payouts/PayoutsValidator.cs
+++ b/src/NoFrixion.MoneyMoov/Models/Payouts/PayoutsValidator.cs
@@ -379,6 +379,12 @@ public static class PayoutsValidator
             }
         }
 
+        //Prevents creating payouts on the same account
+        if (payout.Destination?.AccountID != null && payout.AccountID == payout.Destination.AccountID)
+        {
+            yield return new ValidationResult($"Source account cannot be the same as destination account.", new string[] { nameof(payout.Destination.AccountID) });
+        }
+
         if (payout.Type != AccountIdentifierType.BTC && !ValidateTheirReference(payout.TheirReference, payout.Type, payout.PaymentProcessor))
         {
             if (payout.PaymentProcessor == PaymentProcessorsEnum.Modulr)


### PR DESCRIPTION
Add check so payouts can't be created with destination as source account. 