### PR TITLE
Added intermediate status for payrun approval.

### DIFF
--- a/src/NoFrixion.MoneyMoov/Enums/PayrunStatus.cs
+++ b/src/NoFrixion.MoneyMoov/Enums/PayrunStatus.cs
@@ -61,4 +61,10 @@ public enum PayrunStatus
     /// Indicates that the pay run has been authorised and is queued for processing.
     /// </summary>
     Queued = 8,
+    
+    /// <summary>
+    /// Indicates that the pay run approval is in progress and
+    /// payouts are being created for the pay run.
+    /// </summary>
+    Approving = 9,
 }


### PR DESCRIPTION
Added intermediate status for payrun approval. This status indicates tha the pay run approval is in progress and payouts are being created for the pay run.