### PR TITLE
MOOV-3666: Deprecate and replace Xero connection status props

### DIFF
--- a/src/NoFrixion.MoneyMoov/Enums/XeroBankFeedConnectionStatusEnum.cs
+++ b/src/NoFrixion.MoneyMoov/Enums/XeroBankFeedConnectionStatusEnum.cs
@@ -1,0 +1,48 @@
+﻿// -----------------------------------------------------------------------------
+//  Filename: XeroBankFeedConnectionStatusEnum.cs
+// 
+//  Description: Defines all the possible statuses for a Xero bank feed connection.
+// 
+//  Author(s):
+//  Axel Granillo (axel@nofrixion.com)
+// 
+//  History:
+//  09 09 2024  Axel Granillo   Created, Remote, Mexico City, Mexico.
+// 
+//  License:
+//  MIT.
+// -----------------------------------------------------------------------------
+
+namespace NoFrixion.MoneyMoov.Enums;
+
+/// <summary>
+/// Defines all the possible statuses for a Xero bank feed connection.
+/// </summary>
+public enum XeroBankFeedConnectionStatusEnum
+{
+    /// <summary>
+    /// Default status. No status has been set.
+    /// </summary>
+    None,
+    
+    /// <summary>
+    /// The bank feed connection has been queued for processing.
+    /// </summary>
+    Pending,
+    
+    /// <summary>
+    /// The bank feed connection is fully operational.
+    /// </summary>
+    Active,
+    
+    /// <summary>
+    /// This means that the respective account on Xero has been Archived/Deleted.
+    /// This status will be used when the Xero bank feed connection ID can no longer be found on Xero.
+    /// </summary>
+    Inactive,
+    
+    /// <summary>
+    /// The bank feed had a failure during the connection process.
+    /// </summary>
+    Failed
+}

--- a/src/NoFrixion.MoneyMoov/Models/Account/PaymentAccount.cs
+++ b/src/NoFrixion.MoneyMoov/Models/Account/PaymentAccount.cs
@@ -165,7 +165,13 @@ public class PaymentAccount
     /// <summary>
     /// Indicates if the payment account is connected to a Xero bank feed.
     /// </summary>
+    [Obsolete("Please use the XeroBankFeedConnectionStatus property.")]
     public bool IsXeroBankFeed { get; set; }
+    
+    /// <summary>
+    /// States the status of the Xero bank feed connection, if applicable.
+    /// </summary>
+    public XeroBankFeedConnectionStatusEnum? XeroBankFeedConnectionStatus { get; set; }
     
     public XeroBankFeedSyncStatusEnum XeroBankFeedSyncStatus { get; set; }
     
@@ -184,6 +190,7 @@ public class PaymentAccount
     /// Indicates that the bank feed connection can no longer be found in Xero.
     /// This can mean that the respective account was archived/deleted in Xero.
     /// </summary>
+    [Obsolete("Please use the XeroBankFeedConnectionStatus property.")]
     public bool XeroBankFeedConnectionInactive { get; set; }
     
     /// <summary>


### PR DESCRIPTION
Deprecates `IsXeroBankFeed` and `XeroBankFeedConnectionInactive` props in favor of a new enum-based `XeroBankFeedConnectionStatus` prop.