### PR TITLE
New account type Tribe

### DIFF
--- a/src/NoFrixion.MoneyMoov/Enums/AccountTypeEnum.cs
+++ b/src/NoFrixion.MoneyMoov/Enums/AccountTypeEnum.cs
@@ -1,0 +1,37 @@
+﻿// -----------------------------------------------------------------------------
+//  Filename: AccountTypeEnum.cs
+// 
+//  Description: Provides an enumeration of account types. Mainly for fee calculations.
+// 
+//  Author(s):
+//  Axel Granillo (axel@nofrixion.com)
+// 
+//  History:
+//  16 07 2024  Axel Granillo   Created, Remote, Mexico City, Mexico.
+// 
+//  License:
+//  Proprietary NoFrixion.
+// -----------------------------------------------------------------------------
+
+namespace NoFrixion.MoneyMoov.Enums;
+
+/// <summary>
+/// Enumeration of all possible account types.
+/// </summary>
+public enum AccountTypeEnum
+{
+    /// <summary>
+    /// Standard accounts. No fees applied.
+    /// </summary>
+    Standard,
+    
+    /// <summary>
+    /// Standard fee accounts. Fees are applied.
+    /// </summary>
+    StandardFee,
+    
+    /// <summary>
+    /// Account associated with Tribe.
+    /// </summary>
+    Tribe,
+}

--- a/src/NoFrixion.MoneyMoov/Models/Account/PaymentAccountCreate.cs
+++ b/src/NoFrixion.MoneyMoov/Models/Account/PaymentAccountCreate.cs
@@ -15,6 +15,8 @@
 // MIT.
 //-----------------------------------------------------------------------------
 
+using NoFrixion.MoneyMoov.Enums;
+
 namespace NoFrixion.MoneyMoov.Models;
 
 public class PaymentAccountCreate
@@ -50,6 +52,17 @@ public class PaymentAccountCreate
     /// For internal use only. Leave empty unless requested otherwise.
     /// </summary>
     public Guid PhysicalAccountID { get; set; }
+    
+    /// <summary>
+    /// If specified the account type will be set to the specified value
+    /// disregarding the merchant default account type.
+    /// </summary>
+    public AccountTypeEnum? AccountType { get; set; }
+    
+    /// <summary>
+    /// If creating a Tribe account type, then this is the tribe account id
+    /// </summary>
+    public string? TribeAccountId { get; set; }
 
     /// <summary>
     /// Places all the payment request's properties into a dictionary.
@@ -64,6 +77,8 @@ public class PaymentAccountCreate
             { nameof(Currency), Currency.ToString() },
             { nameof(AccountName), AccountName ?? string.Empty },
             { nameof(PhysicalAccountID), PhysicalAccountID.ToString() },
+            { nameof(AccountType), AccountType?.ToString() ?? string.Empty },
+            { nameof(TribeAccountId), TribeAccountId ?? string.Empty }
         };
     }
 }


### PR DESCRIPTION
- Added a new account type called "Tribe"
- Removed the default "Unknown" account type from enum as the default should be Standard.
- Moved the AccountTypeEnum to MoneyMoov as it is required to be set when creating payment account.
- The payment account create model now has the option to explicitly set the type and also the tribe account id.