### PR TITLE
Support for receiving data in case of non-success response

### DIFF
--- a/src/NoFrixion.MoneyMoov/RestClient/RestApiClient.cs
+++ b/src/NoFrixion.MoneyMoov/RestClient/RestApiClient.cs
@@ -235,10 +235,6 @@ public class RestApiClient : IRestApiClient, IDisposable
         {
             return contentStr.FromJson<T>();
         }
-        catch (System.Text.Json.JsonException)
-        {
-            return default;
-        }
         catch (Newtonsoft.Json.JsonException)
         {
             return default;

--- a/src/NoFrixion.MoneyMoov/RestClient/RestApiResponse.cs
+++ b/src/NoFrixion.MoneyMoov/RestClient/RestApiResponse.cs
@@ -104,6 +104,13 @@ public class RestApiResponse<T> : RestApiResponse
     public RestApiResponse(HttpStatusCode statusCode, Uri? requestUri, Option<HttpResponseHeaders> headers, NoFrixionProblem problem)
         : base(statusCode, requestUri, headers, problem)
     { }
+
+    public RestApiResponse(HttpStatusCode statusCode, Uri? requestUri, Option<HttpResponseHeaders> headers,
+        NoFrixionProblem problem, T data)
+        : base(statusCode, requestUri, headers, problem)
+    {
+        Data = data;
+    }
  }
 
 /// <summary>


### PR DESCRIPTION
Tribe has a different response model which doesn't quite fit in the RestApiResponse we have. We receive the data even in case of non-success response, and the data has the error message. So added a flag to try and deserialise the data even on error response.