### PR TITLE
Deprecates the PaymentMethodTypes flag enum property in favour of a List

### DIFF
--- a/src/NoFrixion.MoneyMoov/Extensions/EnumExtensions.cs
+++ b/src/NoFrixion.MoneyMoov/Extensions/EnumExtensions.cs
@@ -1,0 +1,55 @@
+//-----------------------------------------------------------------------------
+// Filename: GuidExtensions.cs
+// 
+// Description: Contains extension methods for Guid types:
+// 
+// Author(s):
+// Aaron Clauson (aaron@nofrixion.com)
+// 
+// History:
+// 15 Oct 2024  Aaron Clauson   Created, Carne, Wexford, Ireland.
+// 
+// License:
+// Proprietary NoFrixion.
+//-----------------------------------------------------------------------------
+
+namespace NoFrixion.MoneyMoov;
+
+public static class EnumExtensions
+{
+    /// <summary>
+    /// This method converts an Enum with the Flags attribute to a list of Enums.
+    /// </summary>
+    public static List<T> ToList<T>(this T flags) where T : Enum
+    {
+        if (!typeof(T).IsDefined(typeof(FlagsAttribute), false))
+        {
+            throw new ArgumentException("The type parameter T must have the Flags attribute.", nameof(flags));
+        }
+
+        return Enum.GetValues(typeof(T))
+                   .Cast<T>()
+                   .Where(value => flags.HasFlag(value) && Convert.ToInt32(value) != 0) // Exclude None or 0
+                   .ToList();
+    }
+
+    /// <summary>
+    /// This method converts  list of flag enum values to a single flag enum.
+    /// </summary>
+    public static T ToFlagEnum<T>(this IEnumerable<T> enumValues) where T : Enum
+    {
+        if (!typeof(T).IsDefined(typeof(FlagsAttribute), false))
+        {
+            throw new ArgumentException("The type parameter T must have the Flags attribute.", nameof(enumValues));
+        }
+
+        int result = 0;
+
+        foreach (var value in enumValues)
+        {
+            result |= Convert.ToInt32(value);
+        }
+
+        return (T)Enum.ToObject(typeof(T), result);
+    }
+}

--- a/src/NoFrixion.MoneyMoov/Extensions/EnumExtensions.cs
+++ b/src/NoFrixion.MoneyMoov/Extensions/EnumExtensions.cs
@@ -27,10 +27,23 @@ public static class EnumExtensions
             throw new ArgumentException("The type parameter T must have the Flags attribute.", nameof(flags));
         }
 
-        return Enum.GetValues(typeof(T))
+        // Check if the enum underlying type is ulong
+        var underlyingType = Enum.GetUnderlyingType(typeof(T));
+
+        if (underlyingType == typeof(ulong))
+        {
+            return Enum.GetValues(typeof(T))
                    .Cast<T>()
-                   .Where(value => flags.HasFlag(value) && Convert.ToInt32(value) != 0) // Exclude None or 0
+                   .Where(value => flags.HasFlag(value) && Convert.ToUInt64(value) != 0) // Exclude None or 0
                    .ToList();
+        }
+        else
+        {
+            return Enum.GetValues(typeof(T))
+               .Cast<T>()
+               .Where(value => flags.HasFlag(value) && Convert.ToInt32(value) != 0) // Exclude None or 0
+               .ToList();
+        }
     }
 
     /// <summary>
@@ -43,13 +56,30 @@ public static class EnumExtensions
             throw new ArgumentException("The type parameter T must have the Flags attribute.", nameof(enumValues));
         }
 
-        int result = 0;
+        // Check if the enum underlying type is ulong
+        var underlyingType = Enum.GetUnderlyingType(typeof(T));
 
-        foreach (var value in enumValues)
+        if (underlyingType == typeof(ulong))
         {
-            result |= Convert.ToInt32(value);
-        }
+            ulong result = 0UL;
 
-        return (T)Enum.ToObject(typeof(T), result);
+            foreach (var value in enumValues)
+            {
+                result |= Convert.ToUInt64(value);
+            }
+
+            return (T)Enum.ToObject(typeof(T), result);
+        }
+        else
+        {
+            int result = 0;
+
+            foreach (var value in enumValues)
+            {
+                result |= Convert.ToInt32(value);
+            }
+
+            return (T)Enum.ToObject(typeof(T), result);
+        }
     }
 }

--- a/src/NoFrixion.MoneyMoov/JsonConverters/NumericConverter.cs
+++ b/src/NoFrixion.MoneyMoov/JsonConverters/NumericConverter.cs
@@ -14,7 +14,6 @@
 // MIT.
 //-----------------------------------------------------------------------------
 
-using LanguageExt;
 using System.ComponentModel;
 using System.Text.Json;
 using System.Text.Json.Serialization;

--- a/src/NoFrixion.MoneyMoov/Models/PaymentRequests/IPaymentRequest.cs
+++ b/src/NoFrixion.MoneyMoov/Models/PaymentRequests/IPaymentRequest.cs
@@ -26,7 +26,10 @@ public interface IPaymentRequest
 
     public string? OrderID { get; set; }
 
-    public PaymentMethodTypeEnum PaymentMethodTypes { get; set; }
+    [Obsolete("This field has been deprecated. Please use PaymentMethods instead.")]
+    public PaymentMethodTypeEnum PaymentMethodTypes { get; }
+
+    public List<PaymentMethodTypeEnum> PaymentMethods { get; set; }
 
     public string? Description { get; set; }
 

--- a/src/NoFrixion.MoneyMoov/Models/PaymentRequests/PaymentRequest.cs
+++ b/src/NoFrixion.MoneyMoov/Models/PaymentRequests/PaymentRequest.cs
@@ -60,8 +60,8 @@ public class PaymentRequest : IPaymentRequest, IWebhookPayload
     [Obsolete("This field has been deprecated. Please use PaymentMethods instead.")]
     public PaymentMethodTypeEnum PaymentMethodTypes 
     { 
-        get => 
-            PaymentMethods.Aggregate(PaymentMethodTypeEnum.None, (current, method) => current | method);
+        get =>
+           PaymentMethods.Any() ? PaymentMethods.ToFlagEnum() : PaymentMethodTypeEnum.None;
     }
 
     /// <summary>

--- a/src/NoFrixion.MoneyMoov/Models/PaymentRequests/PaymentRequest.cs
+++ b/src/NoFrixion.MoneyMoov/Models/PaymentRequests/PaymentRequest.cs
@@ -57,7 +57,17 @@ public class PaymentRequest : IPaymentRequest, IWebhookPayload
     /// The payment methods that the payment request supports. When setting using form data
     /// should be supplied as a comma separated list, for example "card, pisp, lightning".
     /// </summary>
-    public PaymentMethodTypeEnum PaymentMethodTypes { get; set; } = PaymentMethodTypeEnum.card;
+    [Obsolete("This field has been deprecated. Please use PaymentMethods instead.")]
+    public PaymentMethodTypeEnum PaymentMethodTypes 
+    { 
+        get => 
+            PaymentMethods.Aggregate(PaymentMethodTypeEnum.None, (current, method) => current | method);
+    }
+
+    /// <summary>
+    /// The payment methods that the payment request supports.
+    /// </summary>
+    public List<PaymentMethodTypeEnum> PaymentMethods { get; set; } = new List<PaymentMethodTypeEnum>();
 
     /// <summary>
     /// An optional description for the payment request. If set this field will appear

--- a/src/NoFrixion.MoneyMoov/Models/PaymentRequests/PaymentRequestCreate.cs
+++ b/src/NoFrixion.MoneyMoov/Models/PaymentRequests/PaymentRequestCreate.cs
@@ -14,6 +14,7 @@
 //-----------------------------------------------------------------------------
 
 using NoFrixion.MoneyMoov.Attributes;
+using NoFrixion.MoneyMoov.Json;
 using System.ComponentModel.DataAnnotations;
 
 namespace NoFrixion.MoneyMoov.Models;
@@ -62,7 +63,13 @@ public class PaymentRequestCreate : IValidatableObject, IPaymentRequest
     /// The payment methods that the payment request supports. When setting using form data
     /// should be supplied as a comma separated list, for example "card, pisp, lightning".
     /// </summary>
-    public PaymentMethodTypeEnum PaymentMethodTypes { get; set; } = PaymentMethodTypeEnum.card;
+    [Obsolete("This field has been deprecated. Please use PaymentMethods instead.")]
+    public PaymentMethodTypeEnum PaymentMethodTypes { get; init; } = PaymentMethodTypeEnum.card;
+
+    /// <summary>
+    /// The payment methods that the payment request supports.
+    /// </summary>
+    public List<PaymentMethodTypeEnum> PaymentMethods { get; set; } = new List<PaymentMethodTypeEnum>();
 
     /// <summary>
     /// An optional description for the payment request. If set this field will appear
@@ -376,7 +383,6 @@ public class PaymentRequestCreate : IValidatableObject, IPaymentRequest
         dict.Add(nameof(Currency), Currency.ToString());
         dict.Add(nameof(CustomerID), CustomerID ?? string.Empty);
         dict.Add(nameof(OrderID), OrderID ?? string.Empty);
-        dict.Add(nameof(PaymentMethodTypes), PaymentMethodTypes.ToString());
         dict.Add(nameof(Description), Description ?? string.Empty);
         dict.Add(nameof(BaseOriginUrl), BaseOriginUrl!);
         dict.Add(nameof(CallbackUrl), CallbackUrl!);
@@ -406,6 +412,16 @@ public class PaymentRequestCreate : IValidatableObject, IPaymentRequest
         dict.Add(nameof(Title), Title ?? string.Empty);
         dict.Add(nameof(PartialPaymentSteps), PartialPaymentSteps ?? string.Empty);
         dict.Add(nameof(NotificationEmailAddresses), NotificationEmailAddresses ?? string.Empty);
+
+        if (PaymentMethods?.Count() > 0)
+        {
+            int paymentMethodNumber = 0;
+            foreach (var paymentMethod in PaymentMethods)
+            {
+                dict.Add($"{nameof(PaymentMethods)}[{paymentMethodNumber}]", paymentMethod.ToString());
+                paymentMethodNumber++;
+            }
+        }
 
         if (TagIds?.Count() > 0)
         {

--- a/src/NoFrixion.MoneyMoov/Models/PaymentRequests/PaymentRequestCreate.cs
+++ b/src/NoFrixion.MoneyMoov/Models/PaymentRequests/PaymentRequestCreate.cs
@@ -64,12 +64,27 @@ public class PaymentRequestCreate : IValidatableObject, IPaymentRequest
     /// should be supplied as a comma separated list, for example "card, pisp, lightning".
     /// </summary>
     [Obsolete("This field has been deprecated. Please use PaymentMethods instead.")]
-    public PaymentMethodTypeEnum PaymentMethodTypes { get; init; } = PaymentMethodTypeEnum.card;
+    public PaymentMethodTypeEnum PaymentMethodTypes {
+        get =>
+            PaymentMethods.Any() ? PaymentMethods.ToFlagEnum() : PaymentMethodTypeEnum.None;
+
+        init 
+        {
+            if(value == PaymentMethodTypeEnum.None)
+            {
+                PaymentMethods.Clear();
+            }
+            else
+            {
+                PaymentMethods = value.ToList();
+            }
+        }
+    }
 
     /// <summary>
     /// The payment methods that the payment request supports.
     /// </summary>
-    public List<PaymentMethodTypeEnum> PaymentMethods { get; set; } = new List<PaymentMethodTypeEnum>();
+    public List<PaymentMethodTypeEnum> PaymentMethods { get; set; } = new() { PaymentMethodTypeEnum.card };
 
     /// <summary>
     /// An optional description for the payment request. If set this field will appear

--- a/src/NoFrixion.MoneyMoov/Models/PaymentRequests/PaymentRequestMinimal.cs
+++ b/src/NoFrixion.MoneyMoov/Models/PaymentRequests/PaymentRequestMinimal.cs
@@ -69,7 +69,17 @@ public class PaymentRequestMinimal
     /// The payment methods that the payment request supports. When setting using form data
     /// should be supplied as a comma separated list, for example "card, pisp, lightning, applePay".
     /// </summary>
-    public PaymentMethodTypeEnum PaymentMethods { get; set; }
+    [Obsolete("This field has been deprecated. Please use PaymentMethodsList instead.")]
+    public PaymentMethodTypeEnum PaymentMethods
+    {
+        get =>
+            PaymentMethodsList.Aggregate(PaymentMethodTypeEnum.None, (current, method) => current | method);
+    }
+
+    /// <summary>
+    /// The payment methods that the payment request supports.
+    /// </summary>
+    public List<PaymentMethodTypeEnum> PaymentMethodsList { get; set; } = new List<PaymentMethodTypeEnum>();
 
     /// <summary>
     /// This is the error returned from the bank which is recorded in payment request events.

--- a/src/NoFrixion.MoneyMoov/Models/PaymentRequests/PaymentRequestUpdate.cs
+++ b/src/NoFrixion.MoneyMoov/Models/PaymentRequests/PaymentRequestUpdate.cs
@@ -45,7 +45,13 @@ public class PaymentRequestUpdate
     /// The payment methods that the payment request supports. When setting using form data
     /// should be supplied as a comma separated list, for example "card, pisp, lightning".
     /// </summary>
+    [Obsolete("This field has been deprecated. Please use PaymentMethods instead.")]
     public PaymentMethodTypeEnum? PaymentMethodTypes { get; set; }
+
+    /// <summary>
+    /// The payment methods that the payment request supports.
+    /// </summary>
+    public List<PaymentMethodTypeEnum>? PaymentMethods { get; set; }
 
     /// <summary>
     /// An optional description for the payment request. If set this field will appear
@@ -248,7 +254,6 @@ public class PaymentRequestUpdate
         if (Currency != null) dict.Add(nameof(Currency), Currency.Value.ToString());
         if (CustomerID != null) dict.Add(nameof(CustomerID), CustomerID);
         if (OrderID != null) dict.Add(nameof(OrderID), OrderID);
-        if (PaymentMethodTypes != null) dict.Add(nameof(PaymentMethodTypes), PaymentMethodTypes.Value.ToString());
         if (Description != null) dict.Add(nameof(Description), Description);
         if (PispAccountID != null) dict.Add(nameof(PispAccountID), PispAccountID.GetValueOrDefault().ToString());
         if (ShippingFirstName != null) dict.Add(nameof(ShippingFirstName), ShippingFirstName);
@@ -273,6 +278,16 @@ public class PaymentRequestUpdate
         if (NotificationEmailAddresses != null) dict.Add(nameof(NotificationEmailAddresses), NotificationEmailAddresses ?? string.Empty);
         if (Title != null) dict.Add(nameof(Title), Title);
         if (PartialPaymentSteps != null) dict.Add(nameof(PartialPaymentSteps), PartialPaymentSteps);
+
+        if (PaymentMethods?.Count() > 0)
+        {
+            int paymentMethodNumber = 0;
+            foreach (var paymentMethod in PaymentMethods)
+            {
+                dict.Add($"{nameof(PaymentMethods)}[{paymentMethodNumber}]", paymentMethod.ToString());
+                paymentMethodNumber++;
+            }
+        }
 
         return dict;
     }

--- a/src/NoFrixion.MoneyMoov/Models/PaymentRequests/PaymentRequestUpdate.cs
+++ b/src/NoFrixion.MoneyMoov/Models/PaymentRequests/PaymentRequestUpdate.cs
@@ -46,7 +46,31 @@ public class PaymentRequestUpdate
     /// should be supplied as a comma separated list, for example "card, pisp, lightning".
     /// </summary>
     [Obsolete("This field has been deprecated. Please use PaymentMethods instead.")]
-    public PaymentMethodTypeEnum? PaymentMethodTypes { get; set; }
+    public PaymentMethodTypeEnum? PaymentMethodTypes
+    {
+        get =>
+            PaymentMethods != null && PaymentMethods.Any() ? PaymentMethods.ToFlagEnum() : PaymentMethodTypeEnum.None;
+
+        init
+        {
+            if (value != null)
+            {
+                if (PaymentMethods == null)
+                {
+                    PaymentMethods = new();
+                }
+
+                if (value == PaymentMethodTypeEnum.None)
+                {
+                    PaymentMethods.Clear();
+                }
+                else
+                {
+                    PaymentMethods = value.Value.ToList();
+                }
+            }
+        }
+    }
 
     /// <summary>
     /// The payment methods that the payment request supports.

--- a/src/NoFrixion.MoneyMoov/Models/PaymentRequests/PaymentRequestValidator.cs
+++ b/src/NoFrixion.MoneyMoov/Models/PaymentRequests/PaymentRequestValidator.cs
@@ -30,10 +30,12 @@ public static class PaymentRequestValidator
         IPaymentRequest paymentRequest,
         ValidationContext validationContext)
     {
+#pragma warning disable CS0618 // Type or member is obsolete
         if (paymentRequest.PaymentMethodTypes == PaymentMethodTypeEnum.None)
         {
             yield return new ValidationResult($"At least one payment method type must be specified.", new string[] { nameof(paymentRequest.PaymentMethodTypes) });
         }
+
         if (paymentRequest.PaymentMethodTypes.HasFlag(PaymentMethodTypeEnum.pisp) &&
             paymentRequest.Currency == CurrencyTypeEnum.EUR &&
             !ValidateAmount(paymentRequest.Amount, paymentRequest.PaymentMethodTypes, paymentRequest.Currency))
@@ -66,6 +68,7 @@ public static class PaymentRequestValidator
             yield return new ValidationResult($"The amount can only be set to 0 when the payment methods are set to a single option of card.",
                 new string[] { nameof(paymentRequest.Amount) });
         }
+#pragma warning restore CS0618 // Type or member is obsolete
 
         if (!string.IsNullOrEmpty(paymentRequest.BaseOriginUrl))
         {

--- a/test/MoneyMoov.UnitTests/Mapping/CsvMapperTests.cs
+++ b/test/MoneyMoov.UnitTests/Mapping/CsvMapperTests.cs
@@ -104,7 +104,9 @@ Company X,Ms Jane Doe,Jane, Doe,blackhole@nofrixion.com,EUR,5001834,26/07/2023,3
         Assert.Equal(39400M, results[0].Model.Amount);
         Assert.Equal(CurrencyTypeEnum.EUR, results[0].Model.Currency);
         Assert.Equal("5001834", results[0].Model.OrderID);
+#pragma warning disable CS0618 // Type or member is obsolete
         Assert.Equal(PaymentMethodTypeEnum.pisp, results[0].Model.PaymentMethodTypes);
+#pragma warning restore CS0618 // Type or member is obsolete
         Assert.Equal("RANGE ROVER TDV8", results[0].Model.Description);
         Assert.Equal("Jane", results[0].Model.ShippingFirstName);
         Assert.Equal("Doe", results[0].Model.ShippingLastName);
@@ -160,7 +162,9 @@ XXX Volvo, ,Deposit,Vehicle,5002027,10000, Order for car XXX , someone@somemotor
         Assert.Equal(10000M, results[0].Model.Amount);
         Assert.Equal(CurrencyTypeEnum.EUR, results[0].Model.Currency);
         Assert.Equal("5002027", results[0].Model.OrderID);
+#pragma warning disable CS0618 // Type or member is obsolete
         Assert.Equal(PaymentMethodTypeEnum.pisp, results[0].Model.PaymentMethodTypes);
+#pragma warning restore CS0618 // Type or member is obsolete
         Assert.Equal("Order for car XXX", results[0].Model.Description);
         Assert.Equal(string.Empty, results[0].Model.ShippingFirstName);
         Assert.Equal(string.Empty, results[0].Model.ShippingLastName);

--- a/test/MoneyMoov.UnitTests/Models/PaymentRequestCreateTests.cs
+++ b/test/MoneyMoov.UnitTests/Models/PaymentRequestCreateTests.cs
@@ -161,7 +161,7 @@ public class PaymentRequestCreateTests
             Currency = CurrencyTypeEnum.EUR,
             CallbackUrl = "https://localhost/good",
             BaseOriginUrl = "https://localhost",
-            PaymentMethodTypes = PaymentMethodTypeEnum.card | PaymentMethodTypeEnum.lightning
+            PaymentMethods = new() { PaymentMethodTypeEnum.card, PaymentMethodTypeEnum.lightning }
         };
 
         var context = new ValidationContext(this, serviceProvider: null, items: null);
@@ -231,7 +231,7 @@ public class PaymentRequestCreateTests
             Amount = 0.99M,
             Currency = CurrencyTypeEnum.EUR,
             CallbackUrl = "https://localhost/callback",
-            PaymentMethodTypes = PaymentMethodTypeEnum.pisp
+            PaymentMethods = new() { PaymentMethodTypeEnum.pisp }
         };
 
         var validationProb = paymentRequest.Validate();
@@ -251,7 +251,7 @@ public class PaymentRequestCreateTests
             Amount = 1.00M,
             Currency = CurrencyTypeEnum.EUR,
             CallbackUrl = "https://localhost/callback",
-            PaymentMethodTypes = PaymentMethodTypeEnum.pisp
+            PaymentMethods = new() { PaymentMethodTypeEnum.pisp }
         };
 
         var validationProb = paymentRequest.Validate();
@@ -271,7 +271,7 @@ public class PaymentRequestCreateTests
             Amount = 1.99M,
             Currency = CurrencyTypeEnum.GBP,
             CallbackUrl = "https://localhost/callback",
-            PaymentMethodTypes = PaymentMethodTypeEnum.pisp
+            PaymentMethods = new() { PaymentMethodTypeEnum.pisp }
         };
 
         var validationProb = paymentRequest.Validate();
@@ -291,7 +291,7 @@ public class PaymentRequestCreateTests
             Amount = 2.00M,
             Currency = CurrencyTypeEnum.GBP,
             CallbackUrl = "https://localhost/callback",
-            PaymentMethodTypes = PaymentMethodTypeEnum.pisp
+            PaymentMethods = new() { PaymentMethodTypeEnum.pisp }
         };
 
         var validationProb = paymentRequest.Validate();
@@ -312,7 +312,7 @@ public class PaymentRequestCreateTests
             Currency = CurrencyTypeEnum.EUR,
             CallbackUrl = "https://localhost/callback",
             BaseOriginUrl = "https://localhost",
-            PaymentMethodTypes = PaymentMethodTypeEnum.card,
+            PaymentMethods = new() { PaymentMethodTypeEnum.card },
             CardCreateToken = true,
             CardCreateTokenMode = CardTokenCreateModes.ConsentNotRequired,
             CustomerEmailAddress = "qa@nofrixion.com"
@@ -336,7 +336,7 @@ public class PaymentRequestCreateTests
             Currency = CurrencyTypeEnum.GBP,
             CallbackUrl = "https://localhost/callback",
             BaseOriginUrl = "https://localhost",
-            PaymentMethodTypes = PaymentMethodTypeEnum.card,
+            PaymentMethods = new() { PaymentMethodTypeEnum.card },
             CardCreateToken = true
         };
 
@@ -359,7 +359,7 @@ public class PaymentRequestCreateTests
             Currency = CurrencyTypeEnum.EUR,
             CallbackUrl = "https://localhost/callback",
             BaseOriginUrl = "https://localhost",
-            PaymentMethodTypes = PaymentMethodTypeEnum.card,
+            PaymentMethods = new() { PaymentMethodTypeEnum.card },
             CardCreateToken = true,
             CustomerEmailAddress = "qa-nofrixion.com"
         };

--- a/test/MoneyMoov.UnitTests/Models/PaymentRequestEmailNotificationTests.cs
+++ b/test/MoneyMoov.UnitTests/Models/PaymentRequestEmailNotificationTests.cs
@@ -54,7 +54,7 @@ public class PaymentRequestEmailNotificationTests : MoneyMoovUnitTestBase<Paymen
         {
             ID = Guid.NewGuid(),
             Currency = CurrencyTypeEnum.EUR,
-            PaymentMethodTypes = PaymentMethodTypeEnum.card | PaymentMethodTypeEnum.pisp,
+            PaymentMethods = new List<PaymentMethodTypeEnum> { PaymentMethodTypeEnum.card, PaymentMethodTypeEnum.pisp },
             CustomerEmailAddress = "jane.doe@nofrixion.com",
             Amount = 10001.99M,
             Title = "Super Title",
@@ -117,7 +117,7 @@ public class PaymentRequestEmailNotificationTests : MoneyMoovUnitTestBase<Paymen
         {
             ID = Guid.NewGuid(),
             Currency = CurrencyTypeEnum.EUR,
-            PaymentMethodTypes = PaymentMethodTypeEnum.card | PaymentMethodTypeEnum.pisp,
+            PaymentMethods = new List<PaymentMethodTypeEnum> { PaymentMethodTypeEnum.card, PaymentMethodTypeEnum.pisp },
             CustomerEmailAddress = "jane.doe@nofrixion.com",
             Amount = 10001.99M,
             Title = "Super Title",

--- a/test/MoneyMoov.UnitTests/Models/PaymentRequestResultTests.cs
+++ b/test/MoneyMoov.UnitTests/Models/PaymentRequestResultTests.cs
@@ -378,7 +378,7 @@ public class PaymentRequestResultTests
         var merchantID = Guid.NewGuid();
         var amount = 0.42M;
         var currency = CurrencyTypeEnum.EUR;
-        var paymentMethods = PaymentMethodTypeEnum.card | PaymentMethodTypeEnum.lightning;
+        var paymentMethods = new List<PaymentMethodTypeEnum> { PaymentMethodTypeEnum.card, PaymentMethodTypeEnum.lightning };
         var description = "desc";
         var customerID = "cid";
         var orderID = "oid";
@@ -392,7 +392,7 @@ public class PaymentRequestResultTests
             MerchantID = merchantID,
             Amount = amount,
             Currency = currency,
-            PaymentMethodTypes = paymentMethods,
+            PaymentMethods = paymentMethods,
             Description = description,
             CustomerID = customerID,
             OrderID = orderID,


### PR DESCRIPTION
As discussed in standup falg enums do not play well with swagger and openapi. This PR replaces the flag enum with a List in the public model while keeping the benefits of the flag enum in the biz logic and data entity.