### PR TITLE
MOOV-3920: Allow null or whitespace email address list for payruns

### DIFF
--- a/src/NoFrixion.MoneyMoov/Attributes/EmailAddressMultipleAttribute.cs
+++ b/src/NoFrixion.MoneyMoov/Attributes/EmailAddressMultipleAttribute.cs
@@ -38,7 +38,7 @@ public class EmailAddressMultipleAttribute : DataTypeAttribute
 
         if (string.IsNullOrWhiteSpace(emailAddresses))
         {
-            return false;
+            return true;
         }
 
         var emails = emailAddresses.Split(new[] { ';', ' ', ',' }, StringSplitOptions.RemoveEmptyEntries);


### PR DESCRIPTION
Allow null, empty or whitespace strings for the remittance email list through the EmailAddressMultiple atttribute.