### PR TITLE
Expand HMAC functionality

### DIFF
--- a/src/NoFrixion.MoneyMoov/Enums/SharedSecretAlgorithmsEnum.cs
+++ b/src/NoFrixion.MoneyMoov/Enums/SharedSecretAlgorithmsEnum.cs
@@ -1,0 +1,35 @@
+﻿//-----------------------------------------------------------------------------
+// Filename: SharedSecretAlgorithmsEnum.cs
+// 
+// Description: A list of the shared secret algorithms supported. Original use
+// case was for adding an HMAC option to the merchant tokens.
+// 
+// Author(s):
+// Aaron Clauson (aaron@nofrixion.com)
+// 
+// History:
+// Halloween 2024   Aaron Clauson   Created, Carne, Wexford, Ireland.
+// 
+// License:
+// Proprietary NoFrixion.
+//-----------------------------------------------------------------------------
+
+namespace NoFrixion.MoneyMoov;
+
+public enum SharedSecretAlgorithmsEnum
+{
+    None,
+    
+    /// <summary>
+    /// Only supported for legacy reasons. NOT supported for merchant or api token HMACs
+    /// </summary>
+    HMAC_SHA1,
+
+    HMAC_SHA256,
+    HMAC_SHA384,
+
+    /// <summary>
+    /// Recommended.
+    /// </summary>
+    HMAC_SHA512
+}

--- a/src/NoFrixion.MoneyMoov/HmacSignature/HmacAuthenticationConstants.cs
+++ b/src/NoFrixion.MoneyMoov/HmacSignature/HmacAuthenticationConstants.cs
@@ -26,4 +26,5 @@ public static class HmacAuthenticationConstants
     public const string NOFRIXION_SIGNATURE_HEADER_NAME = "x-nfx-signature";
     public const string HTTP_RETRY_HEADER_NAME = "x-mod-retry";
     public const string IDEMPOTENT_HEADER_NAME = "idempotency-key";
+    public const string TOKEN_ID_PARAMETER_NAME = "tokenId";
 }

--- a/src/NoFrixion.MoneyMoov/HmacSignature/HmacSignatureAuthHelper.cs
+++ b/src/NoFrixion.MoneyMoov/HmacSignature/HmacSignatureAuthHelper.cs
@@ -22,13 +22,33 @@ namespace NoFrixion.MoneyMoov;
 
 public static class HmacSignatureAuthHelper
 {
+    /// <summary>
+    /// Original HMAC signature format.
+    /// </summary>
+    public const int LEGACY_SIGNATURE_VERSION = 0;
+
+    /// <summary>
+    /// The current default signature version for the NoFrixion Trusted Third Party (TPP) API key and
+    /// mercant token requests.
+    /// </summary>
+    public const int DEFAULT_SIGNATURE_VERSION = 1;
+
+    /// <summary>
+    /// The HMAC SHA256 signature for the NoFrixion Trusted Third Party (TPP) API key requests. 
+    /// </summary>
+    /// <param name="appId">The ID of the TPP application the signature is for.</param>
+    /// <param name="idempotencyKey">A pseudo-random nonce.</param>
+    /// <param name="secret">The shared HMAC secret.</param>
+    /// <param name="date">The current date time.</param>
+    /// <param name="merchantId">The ID of the merchant the request is for.</param>
+    /// <returns>A list of headers for the ougoing request.</returns>
     public static Dictionary<string, string> GetAppHeaders(string appId,
         string idempotencyKey,
         string secret,
         DateTime date,
         Guid merchantId)
     {
-        var signature = GenerateSignature(idempotencyKey, date, secret, true);
+        var signature = GenerateSignature(idempotencyKey, date, secret, DEFAULT_SIGNATURE_VERSION, SharedSecretAlgorithmsEnum.HMAC_SHA256);
 
         var headers = new Dictionary<string, string>
         {
@@ -41,13 +61,22 @@ public static class HmacSignatureAuthHelper
         return headers;
     }
     
+    /// <summary>
+    /// The original HMAC SHA1 signature used in version 1 webhooks which.
+    /// </summary>
+    /// <param name="keyId">The key ID, or webhook entity ID, the signature is being generated for.</param>
+    /// <param name="nonce">A pseudo-random nonce.</param>
+    /// <param name="secret">The shared HMAC secret.</param>
+    /// <param name="date">The current date time.</param>
+    /// <param name="asRetry">True if a retry header should be added. Not used in the HMAC.</param>
+    /// <returns>A list of headers for the ougoing request.</returns>
     public static Dictionary<string, string> GetHeaders(string keyId,
         string nonce,
         string secret,
         DateTime date,
         bool asRetry = false)
     {
-        var signature = GenerateSignature(nonce, date, secret);
+        var signature = GenerateSignature(nonce, date, secret, LEGACY_SIGNATURE_VERSION, SharedSecretAlgorithmsEnum.HMAC_SHA1);
 
         var headers = new Dictionary<string, string>
         {
@@ -61,13 +90,21 @@ public static class HmacSignatureAuthHelper
         return headers;
     }
 
-    public static string GenerateSignature(string nonce, DateTime date, string secret, bool hmac256 = false)
-    {
-        return hmac256 ? 
-            HashAndEncode256($"date: {date:R}\n{HmacAuthenticationConstants.IDEMPOTENT_HEADER_NAME}: {nonce}", secret) : 
-            HashAndEncode($"date: {date:R}\n{HmacAuthenticationConstants.NONCE_HEADER_NAME}: {nonce}", secret);
-    }
-    
+    public static string GenerateSignature(string nonce, DateTime date, string secret, int signatureVersion, SharedSecretAlgorithmsEnum algorithm)
+     => GenerateSignature(nonce, date, Encoding.UTF8.GetBytes(secret), signatureVersion, algorithm);
+
+    public static string GenerateSignature(string nonce, DateTime date, byte[] secret, int signatureVersion, SharedSecretAlgorithmsEnum algorithm)
+        => signatureVersion switch
+        {
+            0 => HashAndEncode($"date: {date:R}\n{HmacAuthenticationConstants.NONCE_HEADER_NAME}: {nonce}", 
+                    secret,
+                    algorithm),
+            _ => HashAndEncode($"date: {date:R}\n{HmacAuthenticationConstants.IDEMPOTENT_HEADER_NAME}: {nonce}", 
+                    secret, 
+                    algorithm)
+            // If the HMAC headers, or anything else that impacts the input hash, changes add a new signature version.
+        };
+
     private static string GenerateAppAuthHeaderContent(string apiKey, string signature)
     {
         return $"Signature appId=\"{apiKey}\",headers=\"date {HmacAuthenticationConstants.IDEMPOTENT_HEADER_NAME}\",signature=\"{signature}\"";
@@ -78,28 +115,27 @@ public static class HmacSignatureAuthHelper
         return $"Signature keyId=\"{apiKey}\",headers=\"date x-mod-nonce\",signature=\"{signature}\"";
     }
     
-    private static string HashAndEncode(string message, string secret)
+    public static string HashAndEncode(string message, byte[] secret, SharedSecretAlgorithmsEnum algorithm)
     {
-        var ascii = Encoding.ASCII;
-        
-        HMACSHA1 hmac = new HMACSHA1(ascii.GetBytes(secret));
-        hmac.Initialize();
+        if (algorithm == SharedSecretAlgorithmsEnum.None)
+        {
+            throw new ArgumentException("Algorithm must be specified.", nameof(algorithm));
+        }
 
-        byte[] messageBuffer = ascii.GetBytes(message);
-        byte[] hash = hmac.ComputeHash(messageBuffer);
+        byte[] messageBytes = Encoding.UTF8.GetBytes(message);
+        byte[] hash;
 
-        return WebUtility.UrlEncode(Convert.ToBase64String(hash));
-    }
-    
-    private static string HashAndEncode256(string message, string secret)
-    {
-        var ascii = Encoding.ASCII;
-        
-        var hmac = new HMACSHA256(ascii.GetBytes(secret));
-        hmac.Initialize();
-
-        var messageBuffer = ascii.GetBytes(message);
-        var hash = hmac.ComputeHash(messageBuffer);
+        using (HMAC hmac = algorithm switch
+        {
+            SharedSecretAlgorithmsEnum.HMAC_SHA1 => new HMACSHA1(secret),
+            SharedSecretAlgorithmsEnum.HMAC_SHA256 => new HMACSHA256(secret),
+            SharedSecretAlgorithmsEnum.HMAC_SHA384 => new HMACSHA384(secret),
+            SharedSecretAlgorithmsEnum.HMAC_SHA512 => new HMACSHA512(secret),
+            _ => throw new NotSupportedException($"The algorithm {algorithm} is not supported.")
+        })
+        {
+            hash = hmac.ComputeHash(messageBytes);
+        }
 
         return WebUtility.UrlEncode(Convert.ToBase64String(hash));
     }

--- a/src/NoFrixion.MoneyMoov/HmacSignature/HttpSignatureHeaders.cs
+++ b/src/NoFrixion.MoneyMoov/HmacSignature/HttpSignatureHeaders.cs
@@ -1,0 +1,100 @@
+//-----------------------------------------------------------------------------
+// Filename: HttpSignatureHeaders.cs
+// 
+// Description: Represents the headers used in the HTTP Signature.
+// 
+// Author(s):
+// Aaron Clauson (aaron@nofrixion.com)
+// 
+// History:
+// 20 Nov 2024  Donal O'Connor   Created, Stillorgan Wood, Dublin, Ireland.
+// 
+// License:
+// Proprietary MIY.
+//-----------------------------------------------------------------------------
+
+using System.ComponentModel.DataAnnotations;
+using System.Globalization;
+using System.Net.Http.Headers;
+
+namespace NoFrixion.MoneyMoov;
+
+public class HttpSignatureHeaders
+{
+    public string? Nonce { get; set; }
+
+    public DateTime Date { get; set; } = DateTime.MinValue;
+
+    public string? Signature { get; set; }
+
+    public HttpSignatureHeaders()
+    { }
+
+    public HttpSignatureHeaders(IDictionary<string, string> httpRequestHeaders)
+    {
+        var nonce = httpRequestHeaders[HmacAuthenticationConstants.NONCE_HEADER_NAME].ToString();
+        var date = DateTime.MinValue;
+
+        if (string.IsNullOrEmpty(nonce))
+        {
+            nonce = httpRequestHeaders[HmacAuthenticationConstants.IDEMPOTENT_HEADER_NAME].ToString();
+        }
+
+        Nonce = nonce;
+
+        // Parse the date from the header. Must be in RFC1123 date format. E.g. Fri, 01 Mar 2019 15:00:00 GMT.
+        if (!DateTime.TryParseExact(httpRequestHeaders[HmacAuthenticationConstants.DATE_HEADER_NAME], "R", CultureInfo.InvariantCulture,
+                DateTimeStyles.None, out date))
+        {
+            Date = date;
+        }
+
+        if (AuthenticationHeaderValue.TryParse(httpRequestHeaders[HmacAuthenticationConstants.AUTHORIZATION_HEADER_NAME], out var authorisationHeader))
+        {
+            if (authorisationHeader.Scheme == HmacAuthenticationConstants.SIGNATURE_SCHEME_NAME)
+            {
+                // Split Authentication signature into a dictionary
+                var authenticationParams = authorisationHeader.Parameter?.Split(',')
+                    .Select(p => p.Split('='))
+                    .ToDictionary(keyPair => keyPair[0], keyPair => keyPair[1].Trim('"'));
+
+                Signature = authenticationParams?[HmacAuthenticationConstants.SIGNATURE_SCHEME_NAME.ToLowerInvariant()];
+            }
+        }
+    }
+
+    /// <summary>
+    /// Verifies the headers are valid for the signature version.
+    /// </summary>
+    /// <param name="signatureVersion">The signature version to verify the header values for. Different
+    /// versions are expected to require different header values.</param>
+    /// <returns>If the header values were valid an empty problem, otherwise a problem with a list of errors.</returns>
+    public NoFrixionProblem Verify(int signatureVersion)
+    {
+        List<ValidationResult> headerProblems = new List<ValidationResult>();
+
+        if(string.IsNullOrWhiteSpace(Nonce))
+        {
+            headerProblems.Add(new ValidationResult("Nonce was missing."));
+        }
+
+        if (Date == DateTime.MinValue)
+        {
+            headerProblems.Add(new ValidationResult("Date was missing."));
+        }
+
+        if (string.IsNullOrWhiteSpace(Signature))
+        {
+            headerProblems.Add(new ValidationResult("Signature was missing."));
+        }
+
+        if (headerProblems.Count > 0)
+        {
+           return new NoFrixionProblem("There were one or more validation errors with the HTTP request headers when attempting to validate the authentication signature.", headerProblems);
+        }
+        else
+        {
+            return NoFrixionProblem.Empty;
+        }
+    }
+}

--- a/src/NoFrixion.MoneyMoov/Models/Token/TokenAdd.cs
+++ b/src/NoFrixion.MoneyMoov/Models/Token/TokenAdd.cs
@@ -32,6 +32,12 @@ public class TokenAdd : IValidatableObject
     [Required(ErrorMessage = "Description is required")]
     public string Description { get; set; }
 
+    /// <summary>
+    /// Optional shared secret algorithm to use for HMAC authentication. If set a shared secret will be 
+    /// returned when the token is intially created but not on any subsequent retrievals.
+    /// </summary>
+    public SharedSecretAlgorithmsEnum HmacAlgorithm { get; set; }
+
     public MerchantTokenPermissionsEnum Permissions { get; set; } = MerchantTokenPermissionsEnum.CreatePaymentRequest;
 
     public IEnumerable<ValidationResult> Validate(ValidationContext validationContext)

--- a/src/NoFrixion.MoneyMoov/RestClient/RestApiClient.cs
+++ b/src/NoFrixion.MoneyMoov/RestClient/RestApiClient.cs
@@ -223,7 +223,7 @@ public class RestApiClient : IRestApiClient, IDisposable
         Dictionary<string, string>? headers = null,
         MediaTypeWithQualityHeaderValue? acceptHeader = null)
     {
-        var signatureHeaders = HmacSignatureAuthHelper.GetAppHeaders(
+        var signatureHeaders = HmacSignatureBuilder.GetAppHeaders(
             appID.ToString(), 
             Guid.NewGuid().ToString(), 
             secret, 

--- a/test/MoneyMoov.UnitTests/HmacSignature/HmacSignatureAuthHelperTests.cs
+++ b/test/MoneyMoov.UnitTests/HmacSignature/HmacSignatureAuthHelperTests.cs
@@ -41,7 +41,7 @@ public class HmacSignatureAuthHelperTests
         var secret = "123456Q3MDc2YjNhNDUzMTk1NzljZmVj";
         var nonce = "abdc0084-9a07-463b-ba8c-f47f2285531b";
 
-        var signatureLegacy = HmacSignatureAuthHelper.GenerateSignature(nonce, date, secret, 0, SharedSecretAlgorithmsEnum.HMAC_SHA1);
+        var signatureLegacy = HmacSignatureBuilder.GenerateSignature(nonce, date, secret, 0, SharedSecretAlgorithmsEnum.HMAC_SHA1);
 
         Assert.Equal(existingSignature, signatureLegacy);
 
@@ -59,7 +59,7 @@ public class HmacSignatureAuthHelperTests
         var secret = "password";
         var nonce = "abdc0084-9a07-463b-ba8c-f47f2285531b";
 
-        var signature = HmacSignatureAuthHelper.GenerateSignature(nonce, date, secret, 1, SharedSecretAlgorithmsEnum.HMAC_SHA256);
+        var signature = HmacSignatureBuilder.GenerateSignature(nonce, date, secret, 1, SharedSecretAlgorithmsEnum.HMAC_SHA256);
 
         Assert.NotNull(signature);
 
@@ -78,7 +78,7 @@ public class HmacSignatureAuthHelperTests
         var secret = "123456Q3MDc2YjNhNDUzMTk1NzljZmVj";
         var nonce = "abdc0084-9a07-463b-ba8c-f47f2285531b";
 
-        var signatureV1 = HmacSignatureAuthHelper.GenerateSignature(nonce, date, secret, 1, SharedSecretAlgorithmsEnum.HMAC_SHA512);
+        var signatureV1 = HmacSignatureBuilder.GenerateSignature(nonce, date, secret, 1, SharedSecretAlgorithmsEnum.HMAC_SHA512);
 
         _logger.LogInformation($"Signature: {signatureV1}");
 

--- a/test/MoneyMoov.UnitTests/HmacSignature/HmacSignatureAuthHelperTests.cs
+++ b/test/MoneyMoov.UnitTests/HmacSignature/HmacSignatureAuthHelperTests.cs
@@ -1,0 +1,87 @@
+﻿// -----------------------------------------------------------------------------
+//  Filename: HmacSignatureAuthHelperTests.cs
+// 
+//  Description: HmacSignatureAuthHelper Tests:
+// 
+//  Author(s):
+//  Donal O'Connor (donal@nofrixion.com)
+// 
+//  History:
+//  16 01 2023  Donal O'Connor   Created, Harcourt Street, Dublin, Ireland.
+//  20 11 2024  Aaron Clauson    Moved from NoFrixion.Core to MoneyMoov assembly.  
+//
+//  License:
+//  Proprietary NoFrixion.
+// -----------------------------------------------------------------------------
+
+using Microsoft.Extensions.Logging;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace NoFrixion.MoneyMoov.UnitTests;
+
+public class HmacSignatureAuthHelperTests
+{
+    private readonly ILogger<HmacSignatureAuthHelperTests> _logger;
+    private LoggerFactory _loggerFactory;
+
+    public HmacSignatureAuthHelperTests(ITestOutputHelper testOutputHelper)
+    {
+        _loggerFactory = new LoggerFactory();
+        _loggerFactory.AddProvider(new XunitLoggerProvider(testOutputHelper));
+        _logger = _loggerFactory.CreateLogger<HmacSignatureAuthHelperTests>();
+    }
+
+    [Fact]
+    public void GenerateSignature_Test()
+    {
+        DateTime date = DateTime.Parse("Fri, 13 Jan 2023 12:21:17 GMT");
+        var existingSignature = "qsL1e%2FVbz92f%2FUj3zqEg3bboI%2FA%3D";
+
+        var secret = "123456Q3MDc2YjNhNDUzMTk1NzljZmVj";
+        var nonce = "abdc0084-9a07-463b-ba8c-f47f2285531b";
+
+        var signatureLegacy = HmacSignatureAuthHelper.GenerateSignature(nonce, date, secret, 0, SharedSecretAlgorithmsEnum.HMAC_SHA1);
+
+        Assert.Equal(existingSignature, signatureLegacy);
+
+        _logger.LogInformation($"Signature: {signatureLegacy}");
+    }
+
+    /// <summary>
+    /// Tests that the HMAC generation can cope with a short secret.
+    /// </summary>
+    [Fact]
+    public void Generate_Signature_Short_Password_Test()
+    {
+        DateTime date = DateTime.Parse("Fri, 13 Jan 2023 12:21:17 GMT");
+
+        var secret = "password";
+        var nonce = "abdc0084-9a07-463b-ba8c-f47f2285531b";
+
+        var signature = HmacSignatureAuthHelper.GenerateSignature(nonce, date, secret, 1, SharedSecretAlgorithmsEnum.HMAC_SHA256);
+
+        Assert.NotNull(signature);
+
+        _logger.LogInformation($"Signature: {signature}");
+    }
+
+    /// <summary>
+    /// Tests that a version 1 signature generates the expected signature.
+    /// </summary>
+    [Fact]
+    public void GenerateSignature_Version1_Success()
+    {
+        DateTime date = DateTime.Parse("Wed, 20 Nov 2024 12:21:17 GMT");
+        var existingSignature = "rWnfYK2BqiWrF2xGYdShgUhvFJO8gBWWnHLHKIV1X2KoUalr3Xf1MZ2oxs9%2BKQGyONVcSyVv3th7afcFPh7SPw%3D%3D";
+
+        var secret = "123456Q3MDc2YjNhNDUzMTk1NzljZmVj";
+        var nonce = "abdc0084-9a07-463b-ba8c-f47f2285531b";
+
+        var signatureV1 = HmacSignatureAuthHelper.GenerateSignature(nonce, date, secret, 1, SharedSecretAlgorithmsEnum.HMAC_SHA512);
+
+        _logger.LogInformation($"Signature: {signatureV1}");
+
+        Assert.Equal(existingSignature, signatureV1);
+    }
+}

--- a/test/MoneyMoov.UnitTests/HmacSignature/HmacSignatureBuilderTests.cs
+++ b/test/MoneyMoov.UnitTests/HmacSignature/HmacSignatureBuilderTests.cs
@@ -1,7 +1,7 @@
 ﻿// -----------------------------------------------------------------------------
-//  Filename: HmacSignatureAuthHelperTests.cs
+//  Filename: HmacSignatureBuilderTests.cs
 // 
-//  Description: HmacSignatureAuthHelper Tests:
+//  Description: Unit tests for the HMAC signature builder class.
 // 
 //  Author(s):
 //  Donal O'Connor (donal@nofrixion.com)
@@ -20,16 +20,16 @@ using Xunit.Abstractions;
 
 namespace NoFrixion.MoneyMoov.UnitTests;
 
-public class HmacSignatureAuthHelperTests
+public class HmacSignatureBuilderTests
 {
-    private readonly ILogger<HmacSignatureAuthHelperTests> _logger;
+    private readonly ILogger<HmacSignatureBuilderTests> _logger;
     private LoggerFactory _loggerFactory;
 
-    public HmacSignatureAuthHelperTests(ITestOutputHelper testOutputHelper)
+    public HmacSignatureBuilderTests(ITestOutputHelper testOutputHelper)
     {
         _loggerFactory = new LoggerFactory();
         _loggerFactory.AddProvider(new XunitLoggerProvider(testOutputHelper));
-        _logger = _loggerFactory.CreateLogger<HmacSignatureAuthHelperTests>();
+        _logger = _loggerFactory.CreateLogger<HmacSignatureBuilderTests>();
     }
 
     [Fact]


### PR DESCRIPTION
HMACs are already being used in API key authentication and that's now being expanded as an option for merchant tokens. This PR builds on the existing logic to make it flexible enough to deal with both cases.