### PR TITLE
Payment reference length restriction issue fix.

### DIFF
--- a/src/NoFrixion.MoneyMoov/Models/Payruns/PayrunInvoice.cs
+++ b/src/NoFrixion.MoneyMoov/Models/Payruns/PayrunInvoice.cs
@@ -22,7 +22,6 @@ namespace NoFrixion.MoneyMoov.Models;
 
 public class PayrunInvoice : IValidatableObject
 {
-    public const int PAYRUN_INVOICE_PAYMENT_REFERENCE_MAX_LENGTH = 18;
     
     public Guid ID { get; set; }
     
@@ -132,7 +131,6 @@ public class PayrunInvoice : IValidatableObject
     /// the PaymentReference should remain consistent across all invoices.
     /// If the PaymentReference is not set, one will be generated automatically.
     /// </summary>
-    [MaxLength(PAYRUN_INVOICE_PAYMENT_REFERENCE_MAX_LENGTH, ErrorMessage = "PaymentReference cannot be longer than 18 characters.")]
     public string? PaymentReference { get; set; }
     
     /// <summary>

--- a/test/MoneyMoov.UnitTests/Models/PayrunInvoiceValidatorTests.cs
+++ b/test/MoneyMoov.UnitTests/Models/PayrunInvoiceValidatorTests.cs
@@ -74,11 +74,11 @@ public class PayrunInvoiceValidatorTests
     /// </summary>
     [Theory]
     [InlineData("/")] // No letter or number.
-    [InlineData("--")]// No letter or number.
+    [InlineData("--")] // No letter or number.
     [InlineData(".-/&")] // No letter or number.
     [InlineData("1-A-2-c + + dfg")] // Invalid character '+'.
-    [InlineData("Big Bucks £")]// Invalid character '£'.
-    [InlineData("Big Bucks €")]// Invalid character '€'.
+    [InlineData("Big Bucks £")] // Invalid character '£'.
+    [InlineData("Big Bucks €")] // Invalid character '€'.
     [InlineData(":")] // Invalid initial character, can't be ':' or '-'.
     [InlineData("1-A-2-c + ! + dfg")] // Invalid character '!'.
     [InlineData(".-/& a")] // BC don't support '&' in account name.
@@ -207,14 +207,14 @@ public class PayrunInvoiceValidatorTests
         {
             InvoiceReference = "ref-1",
             Destination =
-            new Counterparty
-            {
-                Name = "Some Biz",
-                Identifier = new AccountIdentifier
+                new Counterparty
                 {
-                    Currency = CurrencyTypeEnum.EUR
-                }
-            },
+                    Name = "Some Biz",
+                    Identifier = new AccountIdentifier
+                    {
+                        Currency = CurrencyTypeEnum.EUR
+                    }
+                },
             Currency = CurrencyTypeEnum.EUR,
             TotalAmount = 11.00M
         };
@@ -326,5 +326,69 @@ public class PayrunInvoiceValidatorTests
         var result = payrunInvoice.Validate();
 
         Assert.True(result.IsEmpty);
+    }
+    
+    [Theory]
+    [InlineData("refe-12")]
+    [InlineData("r12 hsd-2")]
+    [InlineData("Saldo F16")]
+    [InlineData("s-D7 K sdf -")]
+    public void PayrunInvoice_PaymentReferenceValidation_Success(string theirReference)
+    {
+        var payrunInvoice = new PayrunInvoice
+        {
+            InvoiceReference = "ref-1",
+            Currency = CurrencyTypeEnum.EUR,
+            TotalAmount = 11.00M,
+            Destination = new Counterparty
+            {
+                Name = "Some Biz",
+                Identifier = new AccountIdentifier
+                {
+                    IBAN = "IE83MOCK91012396989925",
+                    Currency = CurrencyTypeEnum.EUR
+                }
+            },
+            PaymentReference = theirReference
+        };
+
+        var result = payrunInvoice.Validate();
+
+        Assert.True(result.IsEmpty);
+    }
+    
+    [Theory]
+    [InlineData("-sD7!&K.sdf./", AccountIdentifierType.IBAN)] // Invalid character '!'
+    [InlineData("Saldo F16 + F20", AccountIdentifierType.IBAN)] // Invalid character '+'
+    [InlineData("Saldo F16 _ F20", AccountIdentifierType.IBAN)] // Invalid character '_'
+    [InlineData("dddddddd", AccountIdentifierType.IBAN)] // Only one distinct character
+    [InlineData("-sd6tu89-73.sdf./48 2983", AccountIdentifierType.SCAN)] // Starts with '-'
+    public void PayrunInvoice_PaymentReferenceValidation_Fail(string theirReference,
+        AccountIdentifierType identifierType)
+    {
+        var payrunInvoice = new PayrunInvoice
+        {
+            InvoiceReference = "ref-1",
+            Currency = CurrencyTypeEnum.EUR,
+            TotalAmount = 11.00M,
+            Destination = new Counterparty
+            {
+                Name = "Some Biz",
+                Identifier = new AccountIdentifier
+                {
+                    IBAN = identifierType == AccountIdentifierType.IBAN ? "IE83MOCK91012396989925" : null,
+                    AccountNumber = identifierType == AccountIdentifierType.SCAN ? "12345678" : null,
+                    SortCode = identifierType == AccountIdentifierType.SCAN ? "123456" : null,
+                    Currency = identifierType == AccountIdentifierType.IBAN
+                        ? CurrencyTypeEnum.EUR
+                        : CurrencyTypeEnum.GBP
+                }
+            },
+            PaymentReference = theirReference
+        };
+
+        var result = payrunInvoice.Validate();
+
+        Assert.False(result.IsEmpty);
     }
 }


### PR DESCRIPTION
Payment reference length was restricted to 18 chars earlier. This PR removes that. Relies on the processor independent payout their reference validation.