### PR TITLE
MOOV-4270: Add Sandbox Direct Debit settlement delay seconds field

### DIFF
--- a/src/NoFrixion.MoneyMoov/Models/PaymentRequests/PaymentRequest.cs
+++ b/src/NoFrixion.MoneyMoov/Models/PaymentRequests/PaymentRequest.cs
@@ -358,9 +358,9 @@ public class PaymentRequest : IPaymentRequest, IWebhookPayload, IExportableToCsv
     public PaymentAccount? DestinationAccount { get; set; }
     
     /// <summary>
-    /// Sandbox only. Optional. If set, the simulated Direct Debit settlement will be delayed by the specified number of seconds.
+    /// Sandbox only. Optional. If set, simulated settlements will be delayed by the specified number of seconds.
     /// </summary>
-    public int? SandboxDirectDebitSettleDelayInSeconds { get; set; }
+    public int? SandboxSettleDelayInSeconds { get; set; }
 
     public string CustomerName =>
         Addresses.Any() ? $"{Addresses.First().FirstName} {Addresses.First().LastName}" : string.Empty;

--- a/src/NoFrixion.MoneyMoov/Models/PaymentRequests/PaymentRequest.cs
+++ b/src/NoFrixion.MoneyMoov/Models/PaymentRequests/PaymentRequest.cs
@@ -356,6 +356,11 @@ public class PaymentRequest : IPaymentRequest, IWebhookPayload, IExportableToCsv
     /// Minimal destination account details, if available.
     /// </summary>
     public PaymentAccount? DestinationAccount { get; set; }
+    
+    /// <summary>
+    /// Sandbox only. Optional. If set, the simulated Direct Debit settlement will be delayed by the specified number of seconds.
+    /// </summary>
+    public int? SandboxDirectDebitSettleDelayInSeconds { get; set; }
 
     public string CustomerName =>
         Addresses.Any() ? $"{Addresses.First().FirstName} {Addresses.First().LastName}" : string.Empty;

--- a/src/NoFrixion.MoneyMoov/Models/PaymentRequests/PaymentRequestCreate.cs
+++ b/src/NoFrixion.MoneyMoov/Models/PaymentRequests/PaymentRequestCreate.cs
@@ -343,6 +343,12 @@ public class PaymentRequestCreate : IValidatableObject, IPaymentRequest
     /// Optional, if set it indicates that this payment request will be used to top up a payment account for a pay run.
     /// </summary>
     public Guid? PayrunID { get; set; }
+    
+    /// <summary>
+    /// Sandbox only. Optional. If set, the simulated Direct Debit settlement will be delayed by the specified number of seconds.
+    /// Must be greater than 0 and less than 600. Otherwise, the default value will be used.
+    /// </summary>
+    public int? SandboxDirectDebitSettleDelayInSeconds { get; set; }
 
     /// <summary>
     /// An optional list of tag ids to add to the payment request

--- a/src/NoFrixion.MoneyMoov/Models/PaymentRequests/PaymentRequestCreate.cs
+++ b/src/NoFrixion.MoneyMoov/Models/PaymentRequests/PaymentRequestCreate.cs
@@ -348,7 +348,7 @@ public class PaymentRequestCreate : IValidatableObject, IPaymentRequest
     /// Sandbox only. Optional. If set, the simulated Direct Debit settlement will be delayed by the specified number of seconds.
     /// Must be greater than 0 and less than 600. Otherwise, the default value will be used.
     /// </summary>
-    public int? SandboxDirectDebitSettleDelayInSeconds { get; set; }
+    public int? SandboxSettleDelayInSeconds { get; set; }
 
     /// <summary>
     /// An optional list of tag ids to add to the payment request


### PR DESCRIPTION
Added Sandbox Direct Debit settlement delay in seconds field to payment request models.