### PR TITLE
MOOV-3707: Add Processing payrun state and event type

### DIFF
--- a/src/NoFrixion.MoneyMoov/Enums/PayrunEventTypeEnum.cs
+++ b/src/NoFrixion.MoneyMoov/Enums/PayrunEventTypeEnum.cs
@@ -45,4 +45,6 @@ public enum PayrunEventTypeEnum
     Cancelled = 12,
 
     Authorised = 13,
+    
+    BeganProcessing = 14,
 }

--- a/src/NoFrixion.MoneyMoov/Enums/PayrunStatus.cs
+++ b/src/NoFrixion.MoneyMoov/Enums/PayrunStatus.cs
@@ -62,4 +62,9 @@ public enum PayrunStatus
     /// payouts are being created for the pay run.
     /// </summary>
     Approving = 9,
+    
+    /// <summary>
+    /// Indicates that all submitted payouts are currently being processed.
+    /// </summary>
+    Processing = 10
 }


### PR DESCRIPTION
Added new enum values for a processing state for both payrun status and payrun event types.