### PR TITLE
Remove modulr code

### DIFF
--- a/src/NoFrixion.MoneyMoov/Constants/HttpClientConstants.cs
+++ b/src/NoFrixion.MoneyMoov/Constants/HttpClientConstants.cs
@@ -19,8 +19,6 @@ namespace NoFrixion.MoneyMoov.Constants;
 
 public static class HttpClientConstants
 {
-    public static string HTTP_MODULR_CLIENT_NAME = "Modulr";
-
     public static string HTTP_SIGNATURE_CLIENT_NAME = "HttpSignatureClient";
 
     public static string HTTP_CHECKOUT_CLIENT_NAME = "CheckoutClient";

--- a/src/NoFrixion.MoneyMoov/Enums/PaymentProcessorsEnum.cs
+++ b/src/NoFrixion.MoneyMoov/Enums/PaymentProcessorsEnum.cs
@@ -43,11 +43,6 @@ public enum PaymentProcessorsEnum
     Stripe,
 
     /// <summary>
-    /// Modulr payment initiation processor. 
-    /// </summary>
-    Modulr,
-
-    /// <summary>
     /// Plaid payment initiation processor. 
     /// </summary>
     Plaid,

--- a/src/NoFrixion.MoneyMoov/Enums/PaymentProcessorsEnum.cs
+++ b/src/NoFrixion.MoneyMoov/Enums/PaymentProcessorsEnum.cs
@@ -41,6 +41,12 @@ public enum PaymentProcessorsEnum
     /// Stripe card processor.
     /// </summary>
     Stripe,
+    
+    /// <summary>
+    /// Modulr payment initiation processor. 
+    /// </summary>
+    [Obsolete("Modulr is no longer used.")]
+    Modulr,
 
     /// <summary>
     /// Plaid payment initiation processor. 

--- a/src/NoFrixion.MoneyMoov/Enums/PaymentRequestEventTypesEnum.cs
+++ b/src/NoFrixion.MoneyMoov/Enums/PaymentRequestEventTypesEnum.cs
@@ -87,7 +87,7 @@ public enum PaymentRequestEventTypesEnum
     pisp_webhook = 11,
 
     /// <summary>
-    /// A successful PISP attempt was verified and settled through modulr transaction.
+    /// A successful PISP attempt was verified and settled through transaction.
     /// </summary>
     pisp_settle = 12,
 

--- a/src/NoFrixion.MoneyMoov/Extensions/PaymentRequestExtensions.cs
+++ b/src/NoFrixion.MoneyMoov/Extensions/PaymentRequestExtensions.cs
@@ -191,9 +191,6 @@ public static class PaymentRequestExtensions
                 {
                     var authorisationEvent = pispCallbackOrWebhook switch
                     {
-                        PaymentRequestEvent cbk when cbk.PaymentProcessorName == PaymentProcessorsEnum.Modulr
-                            && cbk.Status == PaymentRequestResult.PISP_MODULR_SUCCESS_STATUS
-                            && cbk.PispBankStatus != PaymentRequestResult.PISP_MODULR_BANK_REJECTED_STATUS => cbk,
                         PaymentRequestEvent cbk when cbk.PaymentProcessorName == PaymentProcessorsEnum.Nofrixion
                         && (cbk.Status == PayoutStatus.QUEUED.ToString() ||
                             cbk.Status == PayoutStatus.QUEUED_UPSTREAM.ToString() ||
@@ -214,8 +211,7 @@ public static class PaymentRequestExtensions
                         _ => null
                     };
 
-                    if (pispCallbackOrWebhook.Status is PaymentRequestResult.PISP_YAPILY_AUTHORISATION_ERROR 
-                        or PaymentRequestResult.PISP_MODULR_AUTHORISATION_ERROR 
+                    if (pispCallbackOrWebhook.Status is PaymentRequestResult.PISP_YAPILY_AUTHORISATION_ERROR
                         or PaymentRequestResult.PISP_NOFRIXION_AUTHORISATION_ERROR)
                     {
                         paymentAttempt.PispAuthorisationFailedAt = pispCallbackOrWebhook.Inserted;

--- a/src/NoFrixion.MoneyMoov/Models/Merchant/Merchant.cs
+++ b/src/NoFrixion.MoneyMoov/Models/Merchant/Merchant.cs
@@ -101,6 +101,7 @@ public class Merchant
     /// <summary>
     /// For internal use only.
     /// </summary>
+    [Obsolete("Modulr is no longer used.")]
     public string? ModulrCustomerID { get; set; }
 
     /// <summary>

--- a/src/NoFrixion.MoneyMoov/Models/PaymentRequests/PaymentRequestResult.cs
+++ b/src/NoFrixion.MoneyMoov/Models/PaymentRequests/PaymentRequestResult.cs
@@ -36,22 +36,6 @@ public class PaymentRequestResult
     public const string PISP_PLAID_SUCCESS_STATUS = "PaymentStatusExecuted";
 
     /// <summary>
-    /// The status returned from Modulr when a PIS payment is successfully initiated in the sandbox
-    /// environment.
-    /// </summary>
-    public const string PISP_MODULR_SUCCESS_STATUS = "EXECUTED";
-
-    /// <summary>
-    /// With Modulr responses an additional AspspPaymentStatus is returned along with the main Status.
-    /// Both need to be checked. Other than rejected all other statuses indicate the payment attempt
-    /// is in progress.
-    /// </summary>
-    /// <remarks>
-    /// See https://modulr.readme.io/docs/single-immediate-payments-overview#payment-initiation-request-lifecycle
-    /// </remarks>
-    public const string PISP_MODULR_BANK_REJECTED_STATUS = "Rejected";
-
-    /// <summary>
     /// The status returned from Yapily when a PIS payment is successfully initiated.
     /// </summary>
     public const string PISP_YAPILY_COMPLETED_STATUS = "COMPLETED";
@@ -70,11 +54,6 @@ public class PaymentRequestResult
     /// NoFrixion payment initiation authorisation error status.
     /// </summary>
     public const string PISP_NOFRIXION_AUTHORISATION_ERROR = "payment_error";
-
-    /// <summary>
-    /// Modulr payment initiation authorisation error status.
-    /// </summary>
-    public const string PISP_MODULR_AUTHORISATION_ERROR = "CONSENT_REJECTED";
 
     /// <summary>
     /// Status for when a mandate has been successfully created in the Banking Circle Direct Debit API.

--- a/src/NoFrixion.MoneyMoov/Models/PaymentRequests/PaymentRequestResult.cs
+++ b/src/NoFrixion.MoneyMoov/Models/PaymentRequests/PaymentRequestResult.cs
@@ -33,8 +33,27 @@ public class PaymentRequestResult
     /// <summary>
     /// The status returned from Plaid when a PIS payment is successfully initiated.
     /// </summary>
+    [Obsolete("Plaid is no longer used.")]
     public const string PISP_PLAID_SUCCESS_STATUS = "PaymentStatusExecuted";
 
+    /// <summary>
+    /// The status returned from Modulr when a PIS payment is successfully initiated in the sandbox
+    /// environment.
+    /// </summary>
+    [Obsolete("Modulr is no longer used.")]
+    public const string PISP_MODULR_SUCCESS_STATUS = "EXECUTED";
+
+    /// <summary>
+    /// With Modulr responses an additional AspspPaymentStatus is returned along with the main Status.
+    /// Both need to be checked. Other than rejected all other statuses indicate the payment attempt
+    /// is in progress.
+    /// </summary>
+    /// <remarks>
+    /// See https://modulr.readme.io/docs/single-immediate-payments-overview#payment-initiation-request-lifecycle
+    /// </remarks>
+    [Obsolete("Modulr is no longer used.")]
+    public const string PISP_MODULR_BANK_REJECTED_STATUS = "Rejected";
+    
     /// <summary>
     /// The status returned from Yapily when a PIS payment is successfully initiated.
     /// </summary>
@@ -54,6 +73,12 @@ public class PaymentRequestResult
     /// NoFrixion payment initiation authorisation error status.
     /// </summary>
     public const string PISP_NOFRIXION_AUTHORISATION_ERROR = "payment_error";
+    
+    /// <summary>
+    /// Modulr payment initiation authorisation error status.
+    /// </summary>
+    [Obsolete("Modulr is no longer used.")]
+    public const string PISP_MODULR_AUTHORISATION_ERROR = "CONSENT_REJECTED";
 
     /// <summary>
     /// Status for when a mandate has been successfully created in the Banking Circle Direct Debit API.

--- a/src/NoFrixion.MoneyMoov/Models/PaymentRequests/PaymentRequestResult.cs
+++ b/src/NoFrixion.MoneyMoov/Models/PaymentRequests/PaymentRequestResult.cs
@@ -33,7 +33,6 @@ public class PaymentRequestResult
     /// <summary>
     /// The status returned from Plaid when a PIS payment is successfully initiated.
     /// </summary>
-    [Obsolete("Plaid is no longer used.")]
     public const string PISP_PLAID_SUCCESS_STATUS = "PaymentStatusExecuted";
 
     /// <summary>

--- a/src/NoFrixion.MoneyMoov/Models/Payouts/PayoutsValidator.cs
+++ b/src/NoFrixion.MoneyMoov/Models/Payouts/PayoutsValidator.cs
@@ -34,7 +34,7 @@ public static class PayoutsValidator
     /// and account number (SCAN) payments . Note that length gets calculated after 
     /// certain non-counted characters have been removed.
     /// </summary>
-    [Obsolete("Modulr is no longer used.")]
+    [Obsolete("Modulr is no longer used. Use REFERENCE_MAXIMUM_BANKING_CIRCLE_LENGTH instead.")]
     public const int THEIR_REFERENCE_SCAN_MAXIMUM_MODULR_LENGTH = 18;
 
     /// <summary>
@@ -42,7 +42,7 @@ public static class PayoutsValidator
     /// (IBAN) payments . Note that length gets calculated after / certain non-counted characters 
     /// have been removed.
     /// </summary>
-    [Obsolete("Modulr is no longer used.")]
+    [Obsolete("Modulr is no longer used. Use REFERENCE_MAXIMUM_BANKING_CIRCLE_LENGTH instead.")]
     public const int THEIR_REFERENCE_IBAN_MAXIMUM_MODULR_LENGTH = 140;
 
     /// <summary>
@@ -61,7 +61,7 @@ public static class PayoutsValidator
     /// and it must contain at least one letter or number.
     /// "Beneficiary name can only have alphanumerics plus full stop, hyphen, forward slash or ampersand"
     /// </remarks>
-    [Obsolete("Modulr is no longer used.")]
+    [Obsolete("Modulr is no longer used. Use BANKING_CIRCLE_ALLOWED_CHARS_REGEX instead.")]
     public const string MODULR_ACCOUNT_NAME_REGEX = @"^['\.\-\/&\s]*?\w+['\.\-\/&\s\w]*$";
 
     /// <summary>
@@ -76,7 +76,7 @@ public static class PayoutsValidator
     /// [^\W_] is actings as \w with the underscore character included. The upstream supplier does not permit
     /// underscore in the Reference (Theirs) field.
     /// </remarks>
-    [Obsolete("Modulr is no longer used.")]
+    [Obsolete("Modulr is no longer used. Use BANKING_CIRCLE_ALLOWED_CHARS_REGEX instead.")]
     public const string THEIR_REFERENCE_MODULR_REGEX = @"^([^\W_]|[\.\-/&\s]){6,}$";
 
     /// <summary>

--- a/src/NoFrixion.MoneyMoov/Models/Payouts/PayoutsValidator.cs
+++ b/src/NoFrixion.MoneyMoov/Models/Payouts/PayoutsValidator.cs
@@ -22,11 +22,71 @@ namespace NoFrixion.MoneyMoov.Models;
 
 public static class PayoutsValidator
 {
+    /// <summary>
+    /// The minimum required length for the Their Reference field. Note that length gets 
+    /// calculated after certain non-counted characters have been removed.
+    /// </summary>
+    [Obsolete("Modulr is no longer used.")]
+    public const int THEIR_REFERENCE_MINIMUM_MODULR_LENGTH = 6;
+
+    /// <summary>
+    /// The maximum allowed length for the Their Reference field for sort code
+    /// and account number (SCAN) payments . Note that length gets calculated after 
+    /// certain non-counted characters have been removed.
+    /// </summary>
+    [Obsolete("Modulr is no longer used.")]
+    public const int THEIR_REFERENCE_SCAN_MAXIMUM_MODULR_LENGTH = 18;
+
+    /// <summary>
+    /// The maximum allowed length for the Their Reference field for International Bank Account Number
+    /// (IBAN) payments . Note that length gets calculated after / certain non-counted characters 
+    /// have been removed.
+    /// </summary>
+    [Obsolete("Modulr is no longer used.")]
+    public const int THEIR_REFERENCE_IBAN_MAXIMUM_MODULR_LENGTH = 140;
 
     /// <summary>
     /// Maximum length of the Your, or External Reference, field.
     /// </summary>
     public const int YOUR_REFERENCE_MAXIMUM_LENGTH = 256;
+    
+    /// <summary>
+    /// Validation regex for the destination account name field.
+    /// </summary>
+    /// <remarks>
+    /// The original regular expression, from the supplier's swagger file was adjusted to match
+    /// what the original intent seems to have been. The original expression allowed any string
+    /// as long as it had at least one letter or number.
+    /// The intent seems to have been to allow only letters (unicode), numbers and '.-/&amp; and spaces
+    /// and it must contain at least one letter or number.
+    /// "Beneficiary name can only have alphanumerics plus full stop, hyphen, forward slash or ampersand"
+    /// </remarks>
+    [Obsolete("Modulr is no longer used.")]
+    public const string MODULR_ACCOUNT_NAME_REGEX = @"^['\.\-\/&\s]*?\w+['\.\-\/&\s\w]*$";
+
+    /// <summary>
+    /// Validation reqex for the Their, or Reference, field. It  must consist of at least 6 
+    /// alphanumeric characters that are not all the same. Optional, uncounted characters include space, 
+    /// hyphen(-), full stop (.), ampersand(&amp;), and forward slash (/). Total of all characters must be 
+    /// equal to or less than 18 for a SCAN (Faster Payments) payment and 140 for an IBAN (SEPA) payment.
+    /// Somewhat misleadingly, the Reference field cannot contain a hyphen, the allowed characters are:
+    /// alpha numeric (including unicode), space, hyphen(-), full stop (.), ampersand(&amp;), and forward slash (/). 
+    /// </summary>
+    /// <remarks>
+    /// [^\W_] is actings as \w with the underscore character included. The upstream supplier does not permit
+    /// underscore in the Reference (Theirs) field.
+    /// </remarks>
+    [Obsolete("Modulr is no longer used.")]
+    public const string THEIR_REFERENCE_MODULR_REGEX = @"^([^\W_]|[\.\-/&\s]){6,}$";
+
+    /// <summary>
+    /// Certain characters in the Their Reference field are not counted towards the minimum and
+    /// maximum length requirements. This regex indicates the list of allow characters that are NOT
+    /// counted.
+    /// </summary>
+    [Obsolete("Modulr is no longer used.")]
+    public const string THEIR_REFERENCE_NON_COUNTED_CHARS_MODULR_REGEX = @"[\.\-/&\s]";
+
 
     /// <summary>
     /// The External Reference, or Your reference, field is the one that gets set locally on the 
@@ -195,6 +255,21 @@ public static class PayoutsValidator
             _ => ValidateBankingCircleStringField(theirReference, REFERENCE_MAXIMUM_BANKING_CIRCLE_LENGTH),
         };
     }
+    
+    [Obsolete("Modulr is no longer used. Banking Circle validation will be used instead.")]
+    public static bool ValidateModulrAccountName(string accountName)
+    {
+        return ValidateBankingCircleStringField(accountName, ACCOUNT_NAME_MAXIMUM_BANKING_CIRCLE_LENGTH);
+    }
+
+    [Obsolete("Modulr is no longer used. Banking Circle validation will be used instead.")]
+    public static bool ValidateModulrTheirReference(
+        string theirReference,
+        AccountIdentifierType desinationIdentifierType)
+    {
+        return ValidateBankingCircleStringField(theirReference, REFERENCE_MAXIMUM_BANKING_CIRCLE_LENGTH);
+    }
+
 
     public static bool ValidateBankingCircleStringField(string field, int maxAllowedLength)
     {

--- a/src/NoFrixion.MoneyMoov/Models/Payouts/PayoutsValidator.cs
+++ b/src/NoFrixion.MoneyMoov/Models/Payouts/PayoutsValidator.cs
@@ -264,18 +264,13 @@ public static class PayoutsValidator
                 yield return new ValidationResult("Destination account name required.", [ nameof(payout.Destination.Name) ]);
             }
 
-            if (payout.Destination?.Name != null && !IsValidAccountName(payout.Destination?.Name ?? string.Empty, payout.PaymentProcessor))
+            if (payout.Destination?.Name != null &&
+                !IsValidAccountName(payout.Destination?.Name ?? string.Empty, payout.PaymentProcessor))
             {
-                if (payout.PaymentProcessor == PaymentProcessorsEnum.Modulr)
-                {
-                    yield return new ValidationResult($"The Destination Account Name is invalid. It can only contain alphanumeric characters plus the ' . - & and space characters.", [ nameof(payout.Destination.Name) ]);
-                }
-                else
-                {
-                    yield return new ValidationResult(
-                        string.Format(BANKING_CIRCLE_STRING_VALIDATION_ERROR_TEMPLATE, "Destination Account Name", ACCOUNT_NAME_MAXIMUM_BANKING_CIRCLE_LENGTH),
-                        [ nameof(payout.Destination.Name) ]);
-                }
+                yield return new ValidationResult(
+                    string.Format(BANKING_CIRCLE_STRING_VALIDATION_ERROR_TEMPLATE, "Destination Account Name",
+                        ACCOUNT_NAME_MAXIMUM_BANKING_CIRCLE_LENGTH),
+                    [nameof(payout.Destination.Name)]);
             }
 
             if (payout.Destination != null &&
@@ -358,20 +353,10 @@ public static class PayoutsValidator
 
         if (!ValidateTheirReference(payout.TheirReference, payout.Type, payout.PaymentProcessor))
         {
-            if (payout.PaymentProcessor == PaymentProcessorsEnum.Modulr)
-            {
-                yield return new ValidationResult("Their reference must consist of at least 6 alphanumeric characters that are not all the same " +
-                    "(non alphanumeric characters do not get counted towards this minimum value). " +
-                    "The allowed characters are alphanumeric, space, hyphen(-), full stop (.), ampersand (&), and forward slash (/). " +
-                    "Total of all characters must be 18 or less and for a SCAN payout and for an IBAN payout must be 140 or less.",
-                    [ nameof(payout.TheirReference) ]);
-            }
-            else
-            {
-                yield return new ValidationResult(
-                    string.Format(BANKING_CIRCLE_STRING_VALIDATION_ERROR_TEMPLATE, "Their Reference", REFERENCE_MAXIMUM_BANKING_CIRCLE_LENGTH),
-                    [ nameof(payout.TheirReference) ]);
-            }
+            yield return new ValidationResult(
+                string.Format(BANKING_CIRCLE_STRING_VALIDATION_ERROR_TEMPLATE, "Their Reference",
+                    REFERENCE_MAXIMUM_BANKING_CIRCLE_LENGTH),
+                [nameof(payout.TheirReference)]);
         }
 
         if (!ValidateYourReference(payout.YourReference))

--- a/src/NoFrixion.MoneyMoov/Models/Payouts/PayoutsValidator.cs
+++ b/src/NoFrixion.MoneyMoov/Models/Payouts/PayoutsValidator.cs
@@ -23,66 +23,48 @@ namespace NoFrixion.MoneyMoov.Models;
 public static class PayoutsValidator
 {
     /// <summary>
-    /// The minimum required length for the Their Reference field. Note that length gets 
-    /// calculated after certain non-counted characters have been removed.
+    /// This constant is obsolete and is no longer used. It was used to validate the Their Reference field
+    /// for Modulr payments.
     /// </summary>
     [Obsolete("Modulr is no longer used.")]
-    public const int THEIR_REFERENCE_MINIMUM_MODULR_LENGTH = 6;
+    public const int THEIR_REFERENCE_MINIMUM_MODULR_LENGTH = 1;
 
     /// <summary>
-    /// The maximum allowed length for the Their Reference field for sort code
-    /// and account number (SCAN) payments . Note that length gets calculated after 
-    /// certain non-counted characters have been removed.
+    /// This constant is obsolete and is no longer used. It was used to validate the Their Reference field
+    /// for Modulr GBP payments.
     /// </summary>
     [Obsolete("Modulr is no longer used. Use REFERENCE_MAXIMUM_BANKING_CIRCLE_LENGTH instead.")]
-    public const int THEIR_REFERENCE_SCAN_MAXIMUM_MODULR_LENGTH = 18;
+    public const int THEIR_REFERENCE_SCAN_MAXIMUM_MODULR_LENGTH = REFERENCE_MAXIMUM_BANKING_CIRCLE_LENGTH;
 
     /// <summary>
-    /// The maximum allowed length for the Their Reference field for International Bank Account Number
-    /// (IBAN) payments . Note that length gets calculated after / certain non-counted characters 
-    /// have been removed.
+    /// This constant is obsolete and is no longer used. It was used to validate the Their Reference field
+    /// for Modulr EUR payments.
     /// </summary>
     [Obsolete("Modulr is no longer used. Use REFERENCE_MAXIMUM_BANKING_CIRCLE_LENGTH instead.")]
-    public const int THEIR_REFERENCE_IBAN_MAXIMUM_MODULR_LENGTH = 140;
+    public const int THEIR_REFERENCE_IBAN_MAXIMUM_MODULR_LENGTH = REFERENCE_MAXIMUM_BANKING_CIRCLE_LENGTH;
 
     /// <summary>
     /// Maximum length of the Your, or External Reference, field.
     /// </summary>
     public const int YOUR_REFERENCE_MAXIMUM_LENGTH = 256;
-    
-    /// <summary>
-    /// Validation regex for the destination account name field.
-    /// </summary>
-    /// <remarks>
-    /// The original regular expression, from the supplier's swagger file was adjusted to match
-    /// what the original intent seems to have been. The original expression allowed any string
-    /// as long as it had at least one letter or number.
-    /// The intent seems to have been to allow only letters (unicode), numbers and '.-/&amp; and spaces
-    /// and it must contain at least one letter or number.
-    /// "Beneficiary name can only have alphanumerics plus full stop, hyphen, forward slash or ampersand"
-    /// </remarks>
-    [Obsolete("Modulr is no longer used. Use BANKING_CIRCLE_ALLOWED_CHARS_REGEX instead.")]
-    public const string MODULR_ACCOUNT_NAME_REGEX = @"^['\.\-\/&\s]*?\w+['\.\-\/&\s\w]*$";
 
     /// <summary>
-    /// Validation reqex for the Their, or Reference, field. It  must consist of at least 6 
-    /// alphanumeric characters that are not all the same. Optional, uncounted characters include space, 
-    /// hyphen(-), full stop (.), ampersand(&amp;), and forward slash (/). Total of all characters must be 
-    /// equal to or less than 18 for a SCAN (Faster Payments) payment and 140 for an IBAN (SEPA) payment.
-    /// Somewhat misleadingly, the Reference field cannot contain a hyphen, the allowed characters are:
-    /// alpha numeric (including unicode), space, hyphen(-), full stop (.), ampersand(&amp;), and forward slash (/). 
+    /// This constant is obsolete and is no longer used. It was used to validate the account name
+    /// for Modulr.
     /// </summary>
-    /// <remarks>
-    /// [^\W_] is actings as \w with the underscore character included. The upstream supplier does not permit
-    /// underscore in the Reference (Theirs) field.
-    /// </remarks>
     [Obsolete("Modulr is no longer used. Use BANKING_CIRCLE_ALLOWED_CHARS_REGEX instead.")]
-    public const string THEIR_REFERENCE_MODULR_REGEX = @"^([^\W_]|[\.\-/&\s]){6,}$";
+    public const string MODULR_ACCOUNT_NAME_REGEX = BANKING_CIRCLE_ALLOWED_CHARS_REGEX;
 
     /// <summary>
-    /// Certain characters in the Their Reference field are not counted towards the minimum and
-    /// maximum length requirements. This regex indicates the list of allow characters that are NOT
-    /// counted.
+    /// This constant is obsolete and is no longer used. It was used to validate the Their Reference field
+    /// for Modulr payments.
+    /// </summary>
+    [Obsolete("Modulr is no longer used. Use BANKING_CIRCLE_ALLOWED_CHARS_REGEX instead.")]
+    public const string THEIR_REFERENCE_MODULR_REGEX = BANKING_CIRCLE_ALLOWED_CHARS_REGEX;
+
+    /// <summary>
+    /// This constant is obsolete and is no longer used. It was used to validate the Their Reference field
+    /// for Modulr payments.
     /// </summary>
     [Obsolete("Modulr is no longer used.")]
     public const string THEIR_REFERENCE_NON_COUNTED_CHARS_MODULR_REGEX = @"[\.\-/&\s]";

--- a/src/NoFrixion.MoneyMoov/Models/Payouts/PayoutsValidator.cs
+++ b/src/NoFrixion.MoneyMoov/Models/Payouts/PayoutsValidator.cs
@@ -22,64 +22,11 @@ namespace NoFrixion.MoneyMoov.Models;
 
 public static class PayoutsValidator
 {
-    /// <summary>
-    /// The minimum required length for the Their Reference field. Note that length gets 
-    /// calculated after certain non-counted characters have been removed.
-    /// </summary>
-    public const int THEIR_REFERENCE_MINIMUM_MODULR_LENGTH = 6;
-
-    /// <summary>
-    /// The maximum allowed length for the Their Reference field for sort code
-    /// and account number (SCAN) payments . Note that length gets calculated after 
-    /// certain non-counted characters have been removed.
-    /// </summary>
-    public const int THEIR_REFERENCE_SCAN_MAXIMUM_MODULR_LENGTH = 18;
-
-    /// <summary>
-    /// The maximum allowed length for the Their Reference field for International Bank Account Number
-    /// (IBAN) payments . Note that length gets calculated after / certain non-counted characters 
-    /// have been removed.
-    /// </summary>
-    public const int THEIR_REFERENCE_IBAN_MAXIMUM_MODULR_LENGTH = 140;
 
     /// <summary>
     /// Maximum length of the Your, or External Reference, field.
     /// </summary>
     public const int YOUR_REFERENCE_MAXIMUM_LENGTH = 256;
-
-    /// <summary>
-    /// Validation regex for the destination account name field.
-    /// </summary>
-    /// <remarks>
-    /// The original regular expression, from the supplier's swagger file was adjusted to match
-    /// what the original intent seems to have been. The original expression allowed any string
-    /// as long as it had at least one letter or number.
-    /// The intent seems to have been to allow only letters (unicode), numbers and '.-/&amp; and spaces
-    /// and it must contain at least one letter or number.
-    /// "Beneficiary name can only have alphanumerics plus full stop, hyphen, forward slash or ampersand"
-    /// </remarks>
-    public const string MODULR_ACCOUNT_NAME_REGEX = @"^['\.\-\/&\s]*?\w+['\.\-\/&\s\w]*$";
-
-    /// <summary>
-    /// Validation reqex for the Their, or Reference, field. It  must consist of at least 6 
-    /// alphanumeric characters that are not all the same. Optional, uncounted characters include space, 
-    /// hyphen(-), full stop (.), ampersand(&amp;), and forward slash (/). Total of all characters must be 
-    /// equal to or less than 18 for a SCAN (Faster Payments) payment and 140 for an IBAN (SEPA) payment.
-    /// Somewhat misleadingly, the Reference field cannot contain a hyphen, the allowed characters are:
-    /// alpha numeric (including unicode), space, hyphen(-), full stop (.), ampersand(&amp;), and forward slash (/). 
-    /// </summary>
-    /// <remarks>
-    /// [^\W_] is actings as \w with the underscore character included. The upstream supplier does not permit
-    /// underscore in the Reference (Theirs) field.
-    /// </remarks>
-    public const string THEIR_REFERENCE_MODULR_REGEX = @"^([^\W_]|[\.\-/&\s]){6,}$";
-
-    /// <summary>
-    /// Certain characters in the Their Reference field are not counted towards the minimum and
-    /// maximum length requirements. This regex indicates the list of allow characters that are NOT
-    /// counted.
-    /// </summary>
-    public const string THEIR_REFERENCE_NON_COUNTED_CHARS_MODULR_REGEX = @"[\.\-/&\s]";
 
     /// <summary>
     /// The External Reference, or Your reference, field is the one that gets set locally on the 
@@ -223,12 +170,10 @@ public static class PayoutsValidator
 
         return processor switch
         {
-            PaymentProcessorsEnum.Modulr => ValidateModulrAccountName(accountName),
             PaymentProcessorsEnum.BankingCircle => ValidateBankingCircleStringField(accountName, ACCOUNT_NAME_MAXIMUM_BANKING_CIRCLE_LENGTH),
             PaymentProcessorsEnum.BankingCircleAgency => ValidateBankingCircleStringField(accountName, ACCOUNT_NAME_MAXIMUM_BANKING_CIRCLE_LENGTH),
             // If the payment processor is not known, or has no specific validations, perform all the validations.
-            _ => ValidateModulrAccountName(accountName) &&
-                ValidateBankingCircleStringField(accountName, ACCOUNT_NAME_MAXIMUM_BANKING_CIRCLE_LENGTH)
+            _ =>ValidateBankingCircleStringField(accountName, ACCOUNT_NAME_MAXIMUM_BANKING_CIRCLE_LENGTH)
         };
     }
 
@@ -244,48 +189,11 @@ public static class PayoutsValidator
 
         return processor switch
         {
-            PaymentProcessorsEnum.Modulr => ValidateModulrTheirReference(theirReference, desinationIdentifierType),
             PaymentProcessorsEnum.BankingCircle => ValidateBankingCircleStringField(theirReference, REFERENCE_MAXIMUM_BANKING_CIRCLE_LENGTH),
             PaymentProcessorsEnum.BankingCircleAgency => ValidateBankingCircleStringField(theirReference, REFERENCE_MAXIMUM_BANKING_CIRCLE_LENGTH),
             // If the payment processor is not known, or has no specific validations, perform all the validations.
-            _ => ValidateModulrTheirReference(theirReference, desinationIdentifierType) &&
-                ValidateBankingCircleStringField(theirReference, REFERENCE_MAXIMUM_BANKING_CIRCLE_LENGTH),
+            _ => ValidateBankingCircleStringField(theirReference, REFERENCE_MAXIMUM_BANKING_CIRCLE_LENGTH),
         };
-    }
-
-    public static bool ValidateModulrAccountName(string accountName)
-    {
-        var accountNameRegex = new Regex(MODULR_ACCOUNT_NAME_REGEX);
-
-        return !string.IsNullOrEmpty(accountName) && accountNameRegex.IsMatch(accountName);
-    }
-
-    public static bool ValidateModulrTheirReference(
-        string theirReference,
-        AccountIdentifierType desinationIdentifierType)
-    {
-        int maxLength = desinationIdentifierType == AccountIdentifierType.IBAN ?
-            THEIR_REFERENCE_IBAN_MAXIMUM_MODULR_LENGTH : THEIR_REFERENCE_SCAN_MAXIMUM_MODULR_LENGTH;
-
-        Regex matchRegex = new Regex(THEIR_REFERENCE_MODULR_REGEX);
-
-        Regex replaceRegex = new Regex(THEIR_REFERENCE_NON_COUNTED_CHARS_MODULR_REGEX);
-        var refClean = replaceRegex.Replace(theirReference, "");
-
-        if (refClean.Length < THEIR_REFERENCE_MINIMUM_MODULR_LENGTH
-            || !matchRegex.IsMatch(theirReference))
-        {
-            return false;
-        }
-
-        // It's not particularly clear but it seems the non-counted characters are only for the minimum length
-        // requirement. The maximum length is the total length of the string after irrespective of the characters.
-        if(theirReference.Length > maxLength)
-        {
-            return false;
-        }
-
-        return theirReference.ToCharArray().Distinct().Count() > 1;
     }
 
     public static bool ValidateBankingCircleStringField(string field, int maxAllowedLength)
@@ -514,28 +422,13 @@ public static class PayoutsValidator
         {
             theirReference = Regex.Replace(theirReference, @"[^a-zA-Z0-9 ]", "");
 
-            if (paymentProcessor == PaymentProcessorsEnum.BankingCircle || paymentProcessor == PaymentProcessorsEnum.BankingCircleAgency)
-            {
-                theirReference = theirReference.Length > REFERENCE_MAXIMUM_BANKING_CIRCLE_LENGTH ?
-                    theirReference.Substring(0, REFERENCE_MAXIMUM_BANKING_CIRCLE_LENGTH) :
-                    theirReference;
-            }
-            else
-            {
-                int theirRefMaxLength = identifierType == AccountIdentifierType.SCAN ?
-                   THEIR_REFERENCE_SCAN_MAXIMUM_MODULR_LENGTH :
-                   THEIR_REFERENCE_IBAN_MAXIMUM_MODULR_LENGTH;
+            theirReference = theirReference.Length > REFERENCE_MAXIMUM_BANKING_CIRCLE_LENGTH
+                ? theirReference.Substring(0, REFERENCE_MAXIMUM_BANKING_CIRCLE_LENGTH)
+                : theirReference;
 
-                theirReference = theirReference.Length > theirRefMaxLength ?
-                    theirReference.Substring(0, theirRefMaxLength) :
-                    theirReference;
-
-                theirReference = theirReference.Length < THEIR_REFERENCE_MINIMUM_MODULR_LENGTH ?
-                    theirReference.PadRight(THEIR_REFERENCE_MINIMUM_MODULR_LENGTH - theirReference.Length, 'X') :
-                    theirReference;
-            }
-
-            return ValidateTheirReference(theirReference, identifierType, paymentProcessor) ? theirReference.Trim() : fallbackTheirReference;
+            return ValidateTheirReference(theirReference, identifierType, paymentProcessor)
+                ? theirReference.Trim()
+                : fallbackTheirReference;
         }
     }
 
@@ -546,11 +439,9 @@ public static class PayoutsValidator
 
     public static string GetTheirReferenceFromInvoices(CurrencyTypeEnum currency, List<string?> invoiceReferences, PaymentProcessorsEnum paymentProcessor)
     {
-        var maxLength = currency == CurrencyTypeEnum.GBP ? THEIR_REFERENCE_SCAN_MAXIMUM_MODULR_LENGTH : THEIR_REFERENCE_IBAN_MAXIMUM_MODULR_LENGTH;
-
         return MakeSafeTheirReference(
             currency == CurrencyTypeEnum.EUR ? AccountIdentifierType.IBAN : AccountIdentifierType.SCAN, 
-            GetDelimitedStringInRange(invoiceReferences, maxLength),
+            GetDelimitedStringInRange(invoiceReferences, REFERENCE_MAXIMUM_BANKING_CIRCLE_LENGTH),
             paymentProcessor);
     }
 

--- a/test/MoneyMoov.UnitTests/Models/PaymentRequestExtensionTests.cs
+++ b/test/MoneyMoov.UnitTests/Models/PaymentRequestExtensionTests.cs
@@ -400,7 +400,6 @@ namespace MoneyMoov.UnitTests.Models
 
         [Theory]
         [InlineData(PaymentRequestResult.PISP_YAPILY_AUTHORISATION_ERROR, PaymentProcessorsEnum.Yapily)]
-        [InlineData(PaymentRequestResult.PISP_MODULR_AUTHORISATION_ERROR, PaymentProcessorsEnum.Modulr)]
         [InlineData(PaymentRequestResult.PISP_NOFRIXION_AUTHORISATION_ERROR, PaymentProcessorsEnum.Nofrixion)]
         public void GetPispPaymentAttempts_Bank_Authorisation_Failure(string status, PaymentProcessorsEnum paymentProcessor)
         {

--- a/test/MoneyMoov.UnitTests/Models/PaymentRequestResultTests.cs
+++ b/test/MoneyMoov.UnitTests/Models/PaymentRequestResultTests.cs
@@ -979,7 +979,7 @@ public class PaymentRequestResultTests
             Currency = entity.Currency,
             Inserted = DateTime.UtcNow.AddSeconds(2),
             EventType = PaymentRequestEventTypesEnum.pisp_callback,
-            Status = PaymentRequestResult.PISP_MODULR_SUCCESS_STATUS,
+            Status = PaymentRequestResult.PISP_YAPILY_COMPLETED_STATUS,
             PispPaymentInitiationID = "xxx",
             PaymentProcessorName = PaymentProcessorsEnum.Yapily
         };
@@ -1226,53 +1226,6 @@ public class PaymentRequestResultTests
         Assert.Equal(decimal.Zero, result.AmountOutstanding());
         Assert.Equal(entity.Currency, result.Currency);
         Assert.Equal(PaymentResultEnum.FullyPaid, result.Result);
-    }
-
-    /// <summary>
-    /// Tests that if the Modulr event has a bank rejected response it does not result in the 
-    /// status being set to Authorized.
-    /// </summary>
-    [Fact]
-    public void Modulr_Bank_Reject_Not_Authorized_Result()
-    {
-        var entity = GetTestPaymentRequest();
-
-        var modulrInitiateEvent = new PaymentRequestEvent
-        {
-            ID = Guid.NewGuid(),
-            PaymentRequestID = entity.ID,
-            Amount = entity.Amount,
-            Currency = entity.Currency,
-            Inserted = DateTime.UtcNow,
-            EventType = PaymentRequestEventTypesEnum.pisp_initiate,
-            Status = PayoutStatus.PENDING.ToString(),
-            PaymentProcessorName = PaymentProcessorsEnum.Modulr,
-            PispPaymentInitiationID = "xxx"
-        };
-
-        var modulrCallbackEvent = new PaymentRequestEvent
-        {
-            ID = Guid.NewGuid(),
-            PaymentRequestID = entity.ID,
-            Amount = entity.Amount,
-            Currency = entity.Currency,
-            Inserted = DateTime.UtcNow,
-            EventType = PaymentRequestEventTypesEnum.pisp_callback,
-            Status = PaymentRequestResult.PISP_MODULR_SUCCESS_STATUS,
-            PaymentProcessorName = PaymentProcessorsEnum.Modulr,
-            PispPaymentInitiationID = "xxx",
-            PispBankStatus = PaymentRequestResult.PISP_MODULR_BANK_REJECTED_STATUS
-        };
-
-        entity.Events = new List<PaymentRequestEvent> { modulrInitiateEvent, modulrCallbackEvent };
-
-        var result = new PaymentRequestResult(entity);
-
-        Assert.Equal(0, result.Amount);
-        Assert.Equal(0, result.PispAmountAuthorized());
-        Assert.Equal(entity.Amount, result.AmountOutstanding());
-        Assert.Equal(entity.Currency, result.Currency);
-        Assert.Equal(PaymentResultEnum.None, result.Result);
     }
 
     /// <summary>

--- a/test/MoneyMoov.UnitTests/Models/PayrunInvoiceValidatorTests.cs
+++ b/test/MoneyMoov.UnitTests/Models/PayrunInvoiceValidatorTests.cs
@@ -73,19 +73,15 @@ public class PayrunInvoiceValidatorTests
     /// the validation rules for all processor are applied.
     /// </summary>
     [Theory]
-    [InlineData("/")] // No letter or number.
     [InlineData("--")] // No letter or number.
     [InlineData(".-/&")] // No letter or number.
-    [InlineData("1-A-2-c + + dfg")] // Invalid character '+'.
     [InlineData("Big Bucks £")] // Invalid character '£'.
     [InlineData("Big Bucks €")] // Invalid character '€'.
     [InlineData(":")] // Invalid initial character, can't be ':' or '-'.
     [InlineData("1-A-2-c + ! + dfg")] // Invalid character '!'.
     [InlineData(".-/& a")] // BC don't support '&' in account name.
-    [InlineData("/:")] // BC don't support '/' in account name.
     [InlineData("TELECOMUNICAÇÕES S.A.")] // BC don't support unicode.
     [InlineData("Ç_é")] // BC don't support unicode.
-    [InlineData("NFXN: LTD")] // Modulr don't support ':'
     public void Validate_Account_Name_Fails(string accountName)
     {
         var payrunInvoice = new PayrunInvoice
@@ -287,7 +283,7 @@ public class PayrunInvoiceValidatorTests
     
     [Theory]
     [InlineData("ref-1234647384758475374658372648574726437567373647546373654736374647264sdefgsdfgsdfgadsfgvasfgasfgasdfgasdfgsdfgasdfgsdafgasdfgsdfgasdfgsdfgafgasdfgawsrfgsdfgsdfgsdfg", CurrencyTypeEnum.EUR)] // Too long
-    [InlineData("ref-1234647384755dzfxvxdfbvdsfbgv", CurrencyTypeEnum.GBP)] // Too long
+    [InlineData("ref-1234647384758475374658372648574726437567373647546373654736374647264sdefgsdfgsdfgadsfgvasfgasfgasdfgasdfgsdfgasdfgsdafgasdfgsdfgasdfgsdfgafgasdfgawsrfgsdfgsdfgsdfg", CurrencyTypeEnum.GBP)] // Too long
     public void Invoice_With_PaymentReference_Length_Validation_Failure(string theirReference, CurrencyTypeEnum currency)
     {
         var payrunInvoice = new PayrunInvoice
@@ -399,9 +395,6 @@ public class PayrunInvoiceValidatorTests
     
     [Theory]
     [InlineData("-sD7!&K.sdf./", AccountIdentifierType.IBAN)] // Invalid character '!'
-    [InlineData("Saldo F16 + F20", AccountIdentifierType.IBAN)] // Invalid character '+'
-    [InlineData("Saldo F16 _ F20", AccountIdentifierType.IBAN)] // Invalid character '_'
-    [InlineData("dddddddd", AccountIdentifierType.IBAN)] // Only one distinct character
     [InlineData("-sd6tu89-73.sdf./48 2983", AccountIdentifierType.SCAN)] // Starts with '-'
     public void PayrunInvoice_PaymentReferenceValidation_Fail(string theirReference,
         AccountIdentifierType identifierType)


### PR DESCRIPTION
Remove modulr code. Have made most properties obsolete instead of removing them as these are public models.