### PR TITLE
One step user role assignment for first user

### DIFF
--- a/src/NoFrixion.MoneyMoov/ApiClients/UserInviteClient.cs
+++ b/src/NoFrixion.MoneyMoov/ApiClients/UserInviteClient.cs
@@ -26,8 +26,13 @@ public interface IUserInviteClient
 
     Task<RestApiResponse<UserInvite>> GetUserInviteAsync(string accessToken, Guid userInviteID);
 
-    Task<RestApiResponse<UserInvite>> SendInviteAsync(string userAccessToken, Guid merchantID, string inviteeEmailAddress, string inviteRegistrationUrl,
-        bool sendInviteEmail, string inviteeFirstName, string inviteeLastName);
+    Task<RestApiResponse<UserInvite>> SendInviteAsync(string userAccessToken, Guid merchantID,
+        string inviteeEmailAddress,
+        string inviteRegistrationUrl,
+        bool sendInviteEmail,
+        string inviteeFirstName,
+        string inviteeLastName,
+        Guid? onboardingRoleID = null);
 
     Task<RestApiResponse> ResendUserInviteAsync(Guid userInviteID);
 
@@ -109,12 +114,14 @@ public class UserInviteClient : IUserInviteClient
     /// <param name="sendInviteEmail">True if an email should be sent to the invitee.</param>
     /// <param name="inviteeFirstName">The first name of the person being invited.</param>
     /// <param name="inviteeLastName">The last name of the person being invited.</param>
+    /// <param name="onboardingRoleID">The role ID to automatically assign to the merchant’s very first user.</param>
     public Task<RestApiResponse<UserInvite>> SendInviteAsync(string userAccessToken, Guid merchantID, 
         string inviteeEmailAddress, 
         string inviteRegistrationUrl, 
         bool sendInviteEmail,
         string inviteeFirstName,
-        string inviteeLastName)
+        string inviteeLastName,
+        Guid? onboardingRoleID = null)
     {
         var url = MoneyMoovUrlBuilder.UserInvitesApi.UserInvitesUrl(_apiClient.GetBaseUri().ToString());
 
@@ -127,7 +134,8 @@ public class UserInviteClient : IUserInviteClient
             RegistrationUrl = inviteRegistrationUrl,
             SendInviteEmail = sendInviteEmail,
             InviteeFirstName = inviteeFirstName,
-            InviteeLastName = inviteeLastName
+            InviteeLastName = inviteeLastName,
+            InitialRoleID = onboardingRoleID
         };
 
         return prob switch

--- a/src/NoFrixion.MoneyMoov/ApiClients/UserInviteClient.cs
+++ b/src/NoFrixion.MoneyMoov/ApiClients/UserInviteClient.cs
@@ -32,7 +32,7 @@ public interface IUserInviteClient
         bool sendInviteEmail,
         string inviteeFirstName,
         string inviteeLastName,
-        Guid? onboardingRoleID = null);
+        Guid? initialRoleID = null);
 
     Task<RestApiResponse> ResendUserInviteAsync(Guid userInviteID);
 
@@ -114,14 +114,14 @@ public class UserInviteClient : IUserInviteClient
     /// <param name="sendInviteEmail">True if an email should be sent to the invitee.</param>
     /// <param name="inviteeFirstName">The first name of the person being invited.</param>
     /// <param name="inviteeLastName">The last name of the person being invited.</param>
-    /// <param name="onboardingRoleID">The role ID to automatically assign to the merchant’s very first user.</param>
+    /// <param name="initialRoleID">The role ID to automatically assign to the merchant’s very first user.</param>
     public Task<RestApiResponse<UserInvite>> SendInviteAsync(string userAccessToken, Guid merchantID, 
         string inviteeEmailAddress, 
         string inviteRegistrationUrl, 
         bool sendInviteEmail,
         string inviteeFirstName,
         string inviteeLastName,
-        Guid? onboardingRoleID = null)
+        Guid? initialRoleID = null)
     {
         var url = MoneyMoovUrlBuilder.UserInvitesApi.UserInvitesUrl(_apiClient.GetBaseUri().ToString());
 
@@ -135,7 +135,7 @@ public class UserInviteClient : IUserInviteClient
             SendInviteEmail = sendInviteEmail,
             InviteeFirstName = inviteeFirstName,
             InviteeLastName = inviteeLastName,
-            InitialRoleID = onboardingRoleID
+            InitialRoleID = initialRoleID
         };
 
         return prob switch

--- a/src/NoFrixion.MoneyMoov/Models/UserInvite/UserInvite.cs
+++ b/src/NoFrixion.MoneyMoov/Models/UserInvite/UserInvite.cs
@@ -43,6 +43,12 @@ public class UserInvite
     /// If true, indicates the invitee's email address corresponds to an existing MoneyMoov user.
     /// </summary>
     public bool IsInviteeRegistered { get; set; }
+    
+    /// <summary>
+    /// The role ID to automatically assign to the merchant’s very first user.
+    /// Typically set by the compliance team when the first user is invited to a new merchant.
+    /// </summary>
+    public Guid? InitialRoleID { get; set; }
 
     public UserInviteStatusEnum Status
     {

--- a/src/NoFrixion.MoneyMoov/Models/UserInvite/UserInviteCreate.cs
+++ b/src/NoFrixion.MoneyMoov/Models/UserInvite/UserInviteCreate.cs
@@ -53,6 +53,13 @@ public class UserInviteCreate
     /// how to accept the invite.
     /// </summary>
     public bool SendInviteEmail { get; set; }
+    
+    /// <summary>
+    /// The role ID to automatically assign to the merchant’s very first user. 
+    /// This property can only be set when the merchant has no users with roles.
+    /// Typically set by the compliance team when the first user is invited to a new merchant.
+    /// </summary>
+    public Guid? InitialRoleID { get; set; }
 
     /// <summary>
     /// Places all the user invite create's properties into a dictionary.
@@ -67,7 +74,8 @@ public class UserInviteCreate
             { nameof(RegistrationUrl), RegistrationUrl ?? string.Empty },
             { nameof(SendInviteEmail), SendInviteEmail.ToString() },
             {nameof(InviteeFirstName), InviteeFirstName ?? string.Empty},
-            {nameof(InviteeLastName), InviteeLastName ?? string.Empty}
+            {nameof(InviteeLastName), InviteeLastName ?? string.Empty},
+            { nameof(InitialRoleID), InitialRoleID?.ToString() ?? string.Empty }
         };
     }
 }


### PR DESCRIPTION
Added a property to UserInvite and UserInviteCreate called InitialRoleID to indicate the initial role assignment for first user of merchant.