### PR TITLE
MOOV-4542: Add fields for merchant logos for PNG and SVG

### DIFF
--- a/src/NoFrixion.MoneyMoov/Models/Merchant/Merchant.cs
+++ b/src/NoFrixion.MoneyMoov/Models/Merchant/Merchant.cs
@@ -125,6 +125,16 @@ public class Merchant
     /// The name of the role for the identity that loaded the merchant record.
     /// </summary>
     public string? YourRoleName { get; set; }
+    
+    /// <summary>
+    /// The CDN URL of the merchant's logo in PNG format.
+    /// </summary>
+    public string? LogoUrlPng { get; set; }
+    
+    /// <summary>
+    /// The CDN URL of the merchant's logo in SVG format.
+    /// </summary>
+    public string? LogoUrlSvg { get; set; }
 
     /// <summary>
     /// The list of users that have been assigned a role on the merchant.

--- a/src/NoFrixion.MoneyMoov/Models/PaymentRequests/PaymentRequestMinimal.cs
+++ b/src/NoFrixion.MoneyMoov/Models/PaymentRequests/PaymentRequestMinimal.cs
@@ -26,6 +26,10 @@ public class PaymentRequestMinimal
     public string? MerchantName { get; set; }
 
     public string? MerchantShortName { get; set; }
+    
+    public string? MerchantLogoUrlPng { get; set; }
+    
+    public string? MerchantLogoUrlSvg { get; set; }
 
     /// <summary>
     /// The amount of money to request.

--- a/src/NoFrixion.MoneyMoov/Models/PaymentRequests/PaymentRequestPaymentReceipt.cs
+++ b/src/NoFrixion.MoneyMoov/Models/PaymentRequests/PaymentRequestPaymentReceipt.cs
@@ -22,6 +22,10 @@ public class PaymentRequestPaymentReceipt
     public required string MerchantName { get; set; }
     
     public string? MerchantShortName { get; set; }
+    
+    public string? MerchantLogoUrlPng { get; set; }
+    
+    public string? MerchantLogoUrlSvg { get; set; }
 
     public required string MerchantDisplayAddress { get; set; }
 
@@ -42,8 +46,6 @@ public class PaymentRequestPaymentReceipt
     public List<PaymentRequestCustomField>? CustomFields { get; set; }
 
     public string? CustomerName { get; set; }
-
-    public string? MerchantLogoUrl { get; set; }
 
     public string? Title { get; set; }
 


### PR DESCRIPTION
Added new fields for PNG and SVG merchant logos to replace the old way of building the URL with a specific text template and the merchant's short name.