### PR TITLE
Made customer email address nullable

### DIFF
--- a/src/NoFrixion.MoneyMoov/Models/PaymentRequests/PaymentRequestPaymentReceipt.cs
+++ b/src/NoFrixion.MoneyMoov/Models/PaymentRequests/PaymentRequestPaymentReceipt.cs
@@ -47,7 +47,7 @@ public class PaymentRequestPaymentReceipt
 
     public string? Description { get; set; }
     
-    public required string CustomerEmailAddress { get; set; }
+    public string? CustomerEmailAddress { get; set; }
 
     public bool ShowDescriptionInEmail => !string.IsNullOrWhiteSpace(Description) ||
                                           !string.IsNullOrWhiteSpace(Title);


### PR DESCRIPTION
Made customer email address nullable as a receipt can be downloaded by the merchant on demand as well.