### PR TITLE
Bugfix/moov 4632 pisp overpaid

### DIFF
--- a/test/MoneyMoov.UnitTests/Models/PaymentRequestExtensionTests.cs
+++ b/test/MoneyMoov.UnitTests/Models/PaymentRequestExtensionTests.cs
@@ -14,7 +14,6 @@
 //-----------------------------------------------------------------------------
 
 using Microsoft.Extensions.Logging;
-using NoFrixion.Biz.MappingExtensions;
 using NoFrixion.MoneyMoov;
 using NoFrixion.MoneyMoov.Extensions;
 using NoFrixion.MoneyMoov.Models;
@@ -456,7 +455,7 @@ namespace MoneyMoov.UnitTests.Models
         }
         
         [Fact]
-        public void GetPispPaymentAttempts_OverPaid_Test()
+        public void GetPispPaymentAttempts_OverPaid_Same_PaymentInitiationID_Test()
         {
             var paymentRequestID = Guid.NewGuid();
             var paymentInitiationID = Guid.NewGuid().ToString();
@@ -493,7 +492,7 @@ namespace MoneyMoov.UnitTests.Models
                 PispPaymentInstitutionName = "Bank of Ireland"
             };
 
-            var pispEvent3 = new PaymentRequestEvent
+            var settleEvent1 = new PaymentRequestEvent
             {
                 ID = Guid.NewGuid(),
                 PaymentRequestID = paymentRequestID,
@@ -508,7 +507,7 @@ namespace MoneyMoov.UnitTests.Models
                 PispPaymentInstitutionName = "Bank of Ireland"
             };
 
-            var pispEvent4 = new PaymentRequestEvent
+            var settleEvent2 = new PaymentRequestEvent
             {
                 ID = Guid.NewGuid(),
                 PaymentRequestID = paymentRequestID,
@@ -523,15 +522,97 @@ namespace MoneyMoov.UnitTests.Models
                 PispPaymentInstitutionName = "Bank of Ireland"
             };
             
-            var pispEvents = new List<PaymentRequestEvent> { pispEvent1, pispEvent2, pispEvent3, pispEvent4 };
+            var pispEvents = new List<PaymentRequestEvent> { pispEvent1, pispEvent2, settleEvent1, settleEvent2 };
 
             var pispAttempts = pispEvents.GetPispPaymentAttempts();
 
             Assert.NotNull(pispAttempts);
             Assert.NotEmpty(pispAttempts);
             Assert.Equal(2, pispAttempts.Count());
-            Assert.Equal(amount, pispAttempts.First().SettledAmount);
-            Assert.Equal(amount, pispAttempts.First().AuthorisedAmount);
+            Assert.Equal(settleEvent1.Amount + settleEvent2.Amount, pispAttempts.Sum(p => p.SettledAmount));
+            Assert.Equal(settleEvent1.Amount + settleEvent2.Amount, pispAttempts.Sum(p => p.AuthorisedAmount));
+            Assert.Equal(CurrencyTypeEnum.EUR, pispAttempts.First().Currency);
+            Assert.Equal(PaymentProcessorsEnum.Yapily, pispAttempts.First().PaymentProcessor);
+            Assert.Equal(PaymentMethodTypeEnum.pisp, pispAttempts.First().PaymentMethod);
+        }
+        
+        [Fact]
+        public void GetPispPaymentAttempts_OverPaid_Different_PaymentInitiationID_Test()
+        {
+            var paymentRequestID = Guid.NewGuid();
+            var paymentInitiationID = Guid.NewGuid().ToString();
+            var paymentServiceProviderID = "bankofireland";
+            var amount = 12.12m;
+
+            var pispEvent1 = new PaymentRequestEvent
+            {
+                ID = Guid.NewGuid(),
+                PaymentRequestID = paymentRequestID,
+                Amount = amount,
+                Currency = CurrencyTypeEnum.EUR,
+                Inserted = DateTime.UtcNow,
+                EventType = PaymentRequestEventTypesEnum.pisp_initiate,
+                Status = PaymentRequestResult.PISP_YAPILY_PENDING_STATUS,
+                PaymentProcessorName = PaymentProcessorsEnum.Yapily,
+                PispPaymentInitiationID = paymentInitiationID,
+                PispPaymentServiceProviderID = paymentServiceProviderID,
+                PispPaymentInstitutionName = "Bank of Ireland"
+            };
+
+            var pispEvent2 = new PaymentRequestEvent
+            {
+                ID = Guid.NewGuid(),
+                PaymentRequestID = paymentRequestID,
+                Amount = amount,
+                Currency = CurrencyTypeEnum.EUR,
+                Inserted = DateTime.UtcNow,
+                EventType = PaymentRequestEventTypesEnum.pisp_callback,
+                Status = PaymentRequestResult.PISP_YAPILY_COMPLETED_STATUS,
+                PaymentProcessorName = PaymentProcessorsEnum.Yapily,
+                PispPaymentInitiationID = paymentInitiationID,
+                PispPaymentServiceProviderID = paymentServiceProviderID,
+                PispPaymentInstitutionName = "Bank of Ireland"
+            };
+
+            var settleEvent1 = new PaymentRequestEvent
+            {
+                ID = Guid.NewGuid(),
+                PaymentRequestID = paymentRequestID,
+                Amount = amount,
+                Currency = CurrencyTypeEnum.EUR,
+                Inserted = DateTime.UtcNow,
+                EventType = PaymentRequestEventTypesEnum.pisp_settle,
+                Status = PaymentRequestResult.PISP_YAPILY_COMPLETED_STATUS,
+                PaymentProcessorName = PaymentProcessorsEnum.Yapily,
+                PispPaymentInitiationID = paymentInitiationID,
+                PispPaymentServiceProviderID = paymentServiceProviderID,
+                PispPaymentInstitutionName = "Bank of Ireland"
+            };
+
+            var settleEvent2 = new PaymentRequestEvent
+            {
+                ID = Guid.NewGuid(),
+                PaymentRequestID = paymentRequestID,
+                Amount = amount,
+                Currency = CurrencyTypeEnum.EUR,
+                Inserted = DateTime.UtcNow,
+                EventType = PaymentRequestEventTypesEnum.pisp_settle,
+                Status = PaymentRequestResult.PISP_YAPILY_COMPLETED_STATUS,
+                PaymentProcessorName = PaymentProcessorsEnum.Yapily,
+                PispPaymentInitiationID = Guid.NewGuid().ToString(),
+                PispPaymentServiceProviderID = paymentServiceProviderID,
+                PispPaymentInstitutionName = "Bank of Ireland"
+            };
+            
+            var pispEvents = new List<PaymentRequestEvent> { pispEvent1, pispEvent2, settleEvent1, settleEvent2 };
+
+            var pispAttempts = pispEvents.GetPispPaymentAttempts();
+
+            Assert.NotNull(pispAttempts);
+            Assert.NotEmpty(pispAttempts);
+            Assert.Equal(2, pispAttempts.Count());
+            Assert.Equal(settleEvent1.Amount + settleEvent2.Amount, pispAttempts.Sum(p => p.SettledAmount));
+            Assert.Equal(settleEvent1.Amount + settleEvent2.Amount, pispAttempts.Sum(p => p.AuthorisedAmount));
             Assert.Equal(CurrencyTypeEnum.EUR, pispAttempts.First().Currency);
             Assert.Equal(PaymentProcessorsEnum.Yapily, pispAttempts.First().PaymentProcessor);
             Assert.Equal(PaymentMethodTypeEnum.pisp, pispAttempts.First().PaymentMethod);


### PR DESCRIPTION
GetPispPaymentAttempts was not reading all settled events when building the list of payment attempts.

<img width="1532" alt="image" src="https://github.com/user-attachments/assets/3c74ad28-e398-427a-8cef-df7c8dccde64" />
