### PR TITLE
Fix- can’t pay after pisp settle failure

### DIFF
--- a/src/NoFrixion.MoneyMoov/Extensions/PaymentRequestExtensions.cs
+++ b/src/NoFrixion.MoneyMoov/Extensions/PaymentRequestExtensions.cs
@@ -243,6 +243,10 @@ public static class PaymentRequestExtensions
                     var settleFailedEvent = attempt.First(x => x.EventType is PaymentRequestEventTypesEnum.pisp_settle_failure);
 
                     paymentAttempt.SettleFailedAt = settleFailedEvent.Inserted;
+
+                    //Set authorised amount to zero when there is settlement failure for this attempt.
+                    paymentAttempt.AuthorisedAmount = 0;
+
                 }
 
                 pispPaymentAttempts.Add(paymentAttempt);

--- a/test/MoneyMoov.UnitTests/Models/PaymentRequestExtensionTests.cs
+++ b/test/MoneyMoov.UnitTests/Models/PaymentRequestExtensionTests.cs
@@ -222,7 +222,7 @@ namespace MoneyMoov.UnitTests.Models
             Assert.Single(pispAttempts);
             Assert.Equal(PaymentResultEnum.None, pispAttempts.First().Status);
             Assert.Equal(0, pispAttempts.First().SettledAmount);
-            Assert.Equal(amount, pispAttempts.First().AuthorisedAmount);
+            Assert.Equal(0, pispAttempts.First().AuthorisedAmount);
             Assert.Equal(CurrencyTypeEnum.EUR, pispAttempts.First().Currency);
             Assert.Equal(PaymentProcessorsEnum.Yapily, pispAttempts.First().PaymentProcessor);
             Assert.Equal(PaymentMethodTypeEnum.pisp, pispAttempts.First().PaymentMethod);


### PR DESCRIPTION
This case where it's a full payment and a settle failure is recorded. User is still able to pay because AmountPending correctly updated.

<img width="1033" height="274" alt="pisp_fail_attempt1 1" src="https://github.com/user-attachments/assets/4969c318-3b4c-4d7f-9102-b6541572287c" />
<img width="670" height="338" alt="pisp_fail_attempt1 2" src="https://github.com/user-attachments/assets/28fe02a7-ca4c-430d-954f-35f1996a62f5" />

This case where partial payments are enabled. A partial payment is authorised and is pending (2). A second partial payment is authorised but also a settle failure event is recorded for this attempt. Again AmountPending correctly updated and the user can pay.

<img width="1044" height="367" alt="pisp_fail_attempt2 1" src="https://github.com/user-attachments/assets/591b2a2a-adac-49e3-9425-cf712f862e1b" />
<img width="656" height="292" alt="pisp_fail_attempt2 2" src="https://github.com/user-attachments/assets/fc1b484c-bf18-454c-bb30-781246f449f2" />

