### PR TITLE
Removed the range validation attribute from the FxDestinationAmount.

### DIFF
--- a/src/NoFrixion.MoneyMoov/Models/Payouts/PayoutCreate.cs
+++ b/src/NoFrixion.MoneyMoov/Models/Payouts/PayoutCreate.cs
@@ -240,7 +240,6 @@ public class PayoutCreate
     /// Optional but one of Amount or FxDestinationAmount must be set. If specified this will be the amount sent to the payee.
     /// The payout's Amount will be dynamically adjusted based on this amount and the FX rate.
     /// </summary>
-    [Range(1.00, double.MaxValue, ErrorMessage = "Minimum value of 1.00 is required for FxDestinationAmount.")]
     public decimal? FxDestinationAmount { get; set; }
 
     /// <summary>

--- a/src/NoFrixion.MoneyMoov/Models/Payouts/PayoutUpdate.cs
+++ b/src/NoFrixion.MoneyMoov/Models/Payouts/PayoutUpdate.cs
@@ -216,7 +216,6 @@ public class PayoutUpdate
     /// Optional but one of Amount or FxDestinationAmount must be set. If specified this will be the amount sent to the payee.
     /// The payout's Amount will be dynamically adjusted based on this amount and the FX rate.
     /// </summary>
-    [Range(1.00, double.MaxValue, ErrorMessage = "Minimum value of 1.00 is required for FxDestinationAmount.")]
     public decimal? FxDestinationAmount { get; set; }
 
     /// <summary>


### PR DESCRIPTION
The attribute meant that if a caller supplied an FxDestinationAmount of 0 it would always fail validtion even if the filed was not being used.