### PR TITLE
Removed space in between amount and currency

### DIFF
--- a/src/NoFrixion.MoneyMoov/Extensions/PaymentAmount.cs
+++ b/src/NoFrixion.MoneyMoov/Extensions/PaymentAmount.cs
@@ -23,7 +23,7 @@ public static class PaymentAmount
     /// Combines the display currency symbol and amount.
     /// </summary>
     public static string DisplayCurrencyAndAmount(CurrencyTypeEnum currency, decimal amount) =>
-        currency.GetCurrencySymbol() + " " + GetDisplayAmount(currency, amount);
+        currency.GetCurrencySymbol() + GetDisplayAmount(currency, amount);
 
     // Decide decimals once, reuse everywhere.
     private static int GetDecimalPlaces(CurrencyTypeEnum currency, decimal amount)


### PR DESCRIPTION
Pablo I suggested that we remove the space between the currency symbol and amount.