### PR TITLE
MOOV-4999: Add MandateID property to payment request models

### DIFF
--- a/src/NoFrixion.MoneyMoov/Models/PaymentRequests/PaymentRequest.cs
+++ b/src/NoFrixion.MoneyMoov/Models/PaymentRequests/PaymentRequest.cs
@@ -392,6 +392,12 @@ public class PaymentRequest : IPaymentRequest, IWebhookPayload, IExportableToCsv
     /// Details of the Direct Debit payment attempt for this payment request, if any.
     /// </summary>
     public DirectDebit.DirectDebitPayment? DirectDebitPayment { get; set; }
+    
+    /// <summary>
+    /// Optional ID of the direct debit mandate associated with this payment request.
+    /// </summary>
+    public Guid? MerchantDirectDebitMandateID { get; set; }
+
 
     public string CustomerName =>
         Addresses.Any() ? $"{Addresses.First().FirstName} {Addresses.First().LastName}" : string.Empty;

--- a/src/NoFrixion.MoneyMoov/Models/PaymentRequests/PaymentRequestCreate.cs
+++ b/src/NoFrixion.MoneyMoov/Models/PaymentRequests/PaymentRequestCreate.cs
@@ -391,6 +391,13 @@ public class PaymentRequestCreate : IValidatableObject, IPaymentRequest
     /// about payment request events.
     /// </summary>
     public List<Guid>? NotificationRoleIDs { get; set; }
+    
+    /// <summary>
+    /// Optional ID of an existing direct debit mandate to associate with this payment request.
+    /// Only applicable when the payment method is direct debit.
+    /// </summary>
+    public Guid? MerchantDirectDebitMandateID { get; set; }
+
 
     public NoFrixionProblem Validate()
     {


### PR DESCRIPTION
Added MerchantDirectDebitMandateID property to the Create- and Get Payment Request models.