### PR TITLE
MOOV-4997: Add TransactedFxRate prop to the Payout model

### DIFF
--- a/src/NoFrixion.MoneyMoov/Models/Payouts/Payout.cs
+++ b/src/NoFrixion.MoneyMoov/Models/Payouts/Payout.cs
@@ -514,6 +514,12 @@ public class Payout : IValidatableObject, IWebhookPayload, IExportableToCsv
     /// </summary>
     public DateTimeOffset? FxQuoteExpiresAt { get; set; }
 
+    /// <summary>
+    /// The actual FX rate applied during settlement, as recorded on the associated transaction.
+    /// Null if the payout has no settled FX transaction.
+    /// </summary>
+    public decimal? TransactedFxRate { get; set; }
+
     public NoFrixionProblem Validate()
     {
         var context = new ValidationContext(this, serviceProvider: null, items: null);


### PR DESCRIPTION
Add a TransactedFxRate property to the Payout response model meant to be populated by the resulting payout's transaction FX rate.