### PR TITLE
MOOV-5002: Set the PaymentAccount model as IWebhookPayload-compatible

### DIFF
--- a/src/NoFrixion.MoneyMoov/Enums/WebhookResourceTypesEnum.cs
+++ b/src/NoFrixion.MoneyMoov/Enums/WebhookResourceTypesEnum.cs
@@ -62,5 +62,10 @@ public enum WebhookResourceTypesEnum
     /// Will trigger notifications for payrun events
     /// </summary>
     Payrun = 128,
+
+    /// <summary>
+    /// Will trigger notifications for payment account related events.
+    /// </summary>
+    PaymentAccount = 256,
 }
 

--- a/src/NoFrixion.MoneyMoov/Models/Account/PaymentAccount.cs
+++ b/src/NoFrixion.MoneyMoov/Models/Account/PaymentAccount.cs
@@ -24,7 +24,7 @@ namespace NoFrixion.MoneyMoov.Models;
 
 #nullable disable
 
-public class PaymentAccount: IExportableToCsv
+public class PaymentAccount: IExportableToCsv, IWebhookPayload
 {
     /// <summary>
     /// Unique id for the account.


### PR DESCRIPTION
Made the PaymentAccount model implement IWebhookPayload for a new PaymentAccount webhook notification meant to be sent when a new account is automatically created due to reconciliation logic.