### PR TITLE
Add Payment link URL to CSV Export

### DIFF
--- a/src/NoFrixion.MoneyMoov/Extensions/PaymentRequestExtensions.cs
+++ b/src/NoFrixion.MoneyMoov/Extensions/PaymentRequestExtensions.cs
@@ -21,6 +21,53 @@ namespace NoFrixion.MoneyMoov.Extensions;
 
 public static class PaymentRequestExtensions
 {
+    private static readonly string[] PaymentRequestCsvColumns =
+    [
+        "ID",
+        "MerchantID",
+        "Amount",
+        "Currency",
+        "PaymentMethods",
+        "Description",
+        "CustomerID",
+        "OrderID",
+        "Inserted",
+        "LastUpdated",
+        "PispAccountID",
+        "PispAccountName",
+        "BaseOriginUrl",
+        "CardAuthorizeOnly",
+        "CardCreateToken",
+        "CardCreateTokenMode",
+        "Status",
+        "PartialPaymentMethod",
+        "CustomerEmailAddress",
+        "CardStripePaymentIntentID",
+        "CardStripePaymentIntentSecret",
+        "NotificationEmailAddresses",
+        "PriorityBankID",
+        "Title",
+        "PartialPaymentSteps",
+        "AmountReceived",
+        "AmountRefunded",
+        "AmountPending",
+        "CreatedByUserID",
+        "CreatedByUserName",
+        "MerchantTokenDescription",
+        "TransactionIDs",
+        "PayrunID",
+        "ShippingAddress",
+        "BillingAddress",
+        "CustomerName",
+        "PaymentProcessor",
+        "Tags",
+        "DueDate",
+        "CustomFields",
+        "HostedPayCheckoutUrl"
+    ];
+
+    public static string GetCsvHeader() => string.Join(",", PaymentRequestCsvColumns);
+
     public static List<PaymentRequestPaymentAttempt> GetPaymentAttempts(this IEnumerable<PaymentRequestEvent> events)
     {
         if (events == null || !events.Any())
@@ -512,6 +559,7 @@ public static class PaymentRequestExtensions
             paymentRequest.DueDate?.ToString("o") ?? "",
             paymentRequest.CustomFields?.Select(cf => $"{cf.Name}: {cf.Value}")
                 .Aggregate((current, next) => $"{current}, {next}") ?? "",
+            paymentRequest.HostedPayCheckoutUrl ?? "",
         };
 
 

--- a/src/NoFrixion.MoneyMoov/Models/PaymentRequests/PaymentRequest.cs
+++ b/src/NoFrixion.MoneyMoov/Models/PaymentRequests/PaymentRequest.cs
@@ -512,8 +512,7 @@ public class PaymentRequest : IPaymentRequest, IWebhookPayload, IExportableToCsv
                 });
     }
 
-    public string CsvHeader() =>
-        "ID,MerchantID,Amount,Currency,PaymentMethods,Description,CustomerID,OrderID,Inserted,LastUpdated,PispAccountID,PispAccountName,BaseOriginUrl,CardAuthorizeOnly,CardCreateToken,CardCreateTokenMode,Status,PartialPaymentMethod,CustomerEmailAddress,CardStripePaymentIntentID,CardStripePaymentIntentSecret,NotificationEmailAddresses,PriorityBankID,Title,PartialPaymentSteps,AmountReceived,AmountRefunded,AmountPending,CreatedByUserID,CreatedByUserName,MerchantTokenDescription,TransactionIDs,PayrunID,ShippingAddress,BillingAddress,CustomerName,PaymentProcessor,Tags,DueDate,CustomFields";
+    public string CsvHeader() => PaymentRequestExtensions.GetCsvHeader();
     
     public string ToCsvRow()
     {

--- a/test/MoneyMoov.UnitTests/Models/PaymentRequestExportTests.cs
+++ b/test/MoneyMoov.UnitTests/Models/PaymentRequestExportTests.cs
@@ -1,0 +1,50 @@
+//  -----------------------------------------------------------------------------
+//   Filename: PaymentRequestExportTests.cs
+// 
+//   Description: Unit tests for PaymentRequest CSV export.
+// 
+//   Author(s):
+//   Constantine Nalimov (constantine.nalimov@nofrixion.com)
+// 
+//   History:
+//   13 May 2026  Constantine Nalimov  Created.
+// 
+//   License:
+//   MIT.
+//  -----------------------------------------------------------------------------
+
+using NoFrixion.MoneyMoov.Extensions;
+using NoFrixion.MoneyMoov.Models;
+
+namespace MoneyMoov.UnitTests.Models;
+
+public class PaymentRequestExportTests
+{
+    [Fact]
+    public void PaymentRequest_CsvExport_IncludesHostedPayCheckoutUrl()
+    {
+        var hostedPayCheckoutUrl = "https://api.test.nofrixion.com/pay/testmerchant/order123";
+        var paymentRequest = new PaymentRequest
+        {
+            HostedPayCheckoutUrl = hostedPayCheckoutUrl
+        };
+
+        var header = paymentRequest.CsvHeader();
+        var row = paymentRequest.ToCsvRow();
+
+        Assert.Contains("HostedPayCheckoutUrl", header);
+        Assert.Contains(hostedPayCheckoutUrl, row);
+        Assert.Equal("HostedPayCheckoutUrl", header.Split(',').Last());
+    }
+
+    [Fact]
+    public void PaymentRequest_CsvHeader_ColumnCount_Matches_ToCsvRow()
+    {
+        var paymentRequest = new PaymentRequest();
+
+        var headerColumnCount = PaymentRequestExtensions.GetCsvHeader().Split(',').Length;
+        var rowColumnCount = paymentRequest.ToCsvRow().Split(',').Length;
+
+        Assert.Equal(headerColumnCount, rowColumnCount);
+    }
+}


### PR DESCRIPTION
- centralise hosted pay checkout URL generation in one builder instead of rebuilding `/pay/...` routes across APIs
- add `HostedPayCheckoutUrl` to the end of the payment request CSV export so payment links are included without changing existing column positions
