### PR TITLE
MOOV-5056: Expand supported currencies

### DIFF
--- a/src/NoFrixion.MoneyMoov/Constants/Iso4217CurrencyTable.cs
+++ b/src/NoFrixion.MoneyMoov/Constants/Iso4217CurrencyTable.cs
@@ -8,6 +8,7 @@
 // 
 // History:
 // 22 Apr 2026  Constantine Nalimov   Created, Prague, CZ.
+// 23 Jun 2026  Axel Granillo         Updated for supported currencies.
 // 
 // License:
 // MIT.
@@ -16,7 +17,7 @@
 using NoFrixion.MoneyMoov.Models.Currency;
 
 namespace NoFrixion.MoneyMoov.Constants;
-
+#pragma warning disable CS0618
 public static class Iso4217CurrencyTable
 {
     private static readonly CurrencyInfo NoneCurrencyInfo = new(
@@ -24,27 +25,40 @@ public static class Iso4217CurrencyTable
         "NONE",
         string.Empty,
         0,
-        "?");
+        "?",
+        true);
 
     private static readonly IReadOnlyDictionary<CurrencyTypeEnum, CurrencyInfo> Currencies =
         new Dictionary<CurrencyTypeEnum, CurrencyInfo>
         {
             [CurrencyTypeEnum.None] = NoneCurrencyInfo,
-            [CurrencyTypeEnum.GBP] = new(CurrencyTypeEnum.GBP, "GBP", "826", 2, "£"),
-            [CurrencyTypeEnum.EUR] = new(CurrencyTypeEnum.EUR, "EUR", "978", 2, "€"),
-            [CurrencyTypeEnum.USD] = new(CurrencyTypeEnum.USD, "USD", "840", 2, "$"),
-            [CurrencyTypeEnum.AUD] = new(CurrencyTypeEnum.AUD, "AUD", "036", 2, "$"),
-            [CurrencyTypeEnum.BGN] = new(CurrencyTypeEnum.BGN, "BGN", "975", 2, "лв"),
-            [CurrencyTypeEnum.CAD] = new(CurrencyTypeEnum.CAD, "CAD", "124", 2, "$"),
-            [CurrencyTypeEnum.CZK] = new(CurrencyTypeEnum.CZK, "CZK", "203", 2, "Kč"),
-            [CurrencyTypeEnum.DKK] = new(CurrencyTypeEnum.DKK, "DKK", "208", 2, "kr"),
-            [CurrencyTypeEnum.HUF] = new(CurrencyTypeEnum.HUF, "HUF", "348", 2, "Ft"),
-            [CurrencyTypeEnum.ISK] = new(CurrencyTypeEnum.ISK, "ISK", "352", 0, "kr"),
-            [CurrencyTypeEnum.CHF] = new(CurrencyTypeEnum.CHF, "CHF", "756", 2, "CHF"),
-            [CurrencyTypeEnum.NOK] = new(CurrencyTypeEnum.NOK, "NOK", "578", 2, "kr"),
-            [CurrencyTypeEnum.PLN] = new(CurrencyTypeEnum.PLN, "PLN", "985", 2, "zł"),
-            [CurrencyTypeEnum.RON] = new(CurrencyTypeEnum.RON, "RON", "946", 2, "lei"),
-            [CurrencyTypeEnum.BTC] = new(CurrencyTypeEnum.BTC, "BTC", string.Empty, PaymentsConstants.BITCOIN_ROUNDING_DECIMAL_PLACES, "₿")
+            [CurrencyTypeEnum.GBP] = new(CurrencyTypeEnum.GBP, "GBP", "826", 2, "£", true),
+            [CurrencyTypeEnum.EUR] = new(CurrencyTypeEnum.EUR, "EUR", "978", 2, "€", true),
+            [CurrencyTypeEnum.USD] = new(CurrencyTypeEnum.USD, "USD", "840", 2, "$", true),
+            [CurrencyTypeEnum.AUD] = new(CurrencyTypeEnum.AUD, "AUD", "036", 2, "$", true),
+            [CurrencyTypeEnum.BGN] = new(CurrencyTypeEnum.BGN, "BGN", "975", 2, "лв", true),
+            [CurrencyTypeEnum.CAD] = new(CurrencyTypeEnum.CAD, "CAD", "124", 2, "$", true),
+            [CurrencyTypeEnum.CZK] = new(CurrencyTypeEnum.CZK, "CZK", "203", 2, "Kč", true),
+            [CurrencyTypeEnum.DKK] = new(CurrencyTypeEnum.DKK, "DKK", "208", 2, "kr", true),
+            [CurrencyTypeEnum.HUF] = new(CurrencyTypeEnum.HUF, "HUF", "348", 2, "Ft", true),
+            [CurrencyTypeEnum.ISK] = new(CurrencyTypeEnum.ISK, "ISK", "352", 0, "kr", true),
+            [CurrencyTypeEnum.CHF] = new(CurrencyTypeEnum.CHF, "CHF", "756", 2, "CHF", true),
+            [CurrencyTypeEnum.NOK] = new(CurrencyTypeEnum.NOK, "NOK", "578", 2, "kr", true),
+            [CurrencyTypeEnum.PLN] = new(CurrencyTypeEnum.PLN, "PLN", "985", 2, "zł", true),
+            [CurrencyTypeEnum.RON] = new(CurrencyTypeEnum.RON, "RON", "946", 2, "lei", true),
+            [CurrencyTypeEnum.AED] = new(CurrencyTypeEnum.AED, "AED", "784", 2, "د.إ", true),
+            [CurrencyTypeEnum.CNH] = new(CurrencyTypeEnum.CNH, "CNH", "156", 2, "¥", true), // CNH has no official ISO 4217 numeric code; 156 (CNY) used by convention
+            [CurrencyTypeEnum.HKD] = new(CurrencyTypeEnum.HKD, "HKD", "344", 2, "HK$", true),
+            [CurrencyTypeEnum.ILS] = new(CurrencyTypeEnum.ILS, "ILS", "376", 2, "₪", true),
+            [CurrencyTypeEnum.JPY] = new(CurrencyTypeEnum.JPY, "JPY", "392", 0, "¥", true),
+            [CurrencyTypeEnum.MXN] = new(CurrencyTypeEnum.MXN, "MXN", "484", 2, "$", true),
+            [CurrencyTypeEnum.NZD] = new(CurrencyTypeEnum.NZD, "NZD", "554", 2, "NZ$", true),
+            [CurrencyTypeEnum.SAR] = new(CurrencyTypeEnum.SAR, "SAR", "682", 2, "﷼", true),
+            [CurrencyTypeEnum.SEK] = new(CurrencyTypeEnum.SEK, "SEK", "752", 2, "kr", true),
+            [CurrencyTypeEnum.SGD] = new(CurrencyTypeEnum.SGD, "SGD", "702", 2, "S$", true),
+            [CurrencyTypeEnum.TRY] = new(CurrencyTypeEnum.TRY, "TRY", "949", 2, "₺", true),
+            [CurrencyTypeEnum.ZAR] = new(CurrencyTypeEnum.ZAR, "ZAR", "710", 2, "R", true),
+            [CurrencyTypeEnum.BTC] = new(CurrencyTypeEnum.BTC, "BTC", string.Empty, PaymentsConstants.BITCOIN_ROUNDING_DECIMAL_PLACES, "₿", false)
         };
 
     public static IReadOnlyDictionary<CurrencyTypeEnum, CurrencyInfo> All => Currencies;
@@ -54,3 +68,4 @@ public static class Iso4217CurrencyTable
             ? info
             : NoneCurrencyInfo;
 }
+#pragma warning restore CS0618

--- a/src/NoFrixion.MoneyMoov/Enums/CurrencyTypeEnum.cs
+++ b/src/NoFrixion.MoneyMoov/Enums/CurrencyTypeEnum.cs
@@ -10,6 +10,7 @@
 // 26 10 2021  Donal O'Connor   Created, Carmichael House, Dublin, Ireland.
 // 03 Dec 2021  Aaron Clauson   Renamed from Currency to CurrencyTypeEnum.
 // 13 Feb 2025  Aaron Clauson   Added USD.
+// 23 Jun 2026  Axel Granillo   Added support for additional currencies and marked BGN and ISK as obsolete.
 // 
 //  License:
 //  MIT.
@@ -51,6 +52,7 @@ public enum CurrencyTypeEnum
     /// <summary>
     /// Bulgarian Lev (Fiat).
     /// </summary>
+    [Obsolete("Unsupported currency", false)]
     [EnumMember(Value = "BGN")]
     BGN = 5,
     
@@ -81,6 +83,7 @@ public enum CurrencyTypeEnum
     /// <summary>
     /// Icelandic Krona (Fiat).
     /// </summary>
+    [Obsolete("Unsupported currency", false)]
     [EnumMember(Value = "ISK")]
     ISK = 10,
     
@@ -107,6 +110,78 @@ public enum CurrencyTypeEnum
     /// </summary>
     [EnumMember(Value = "RON")]
     RON = 14,
+    
+    /// <summary>
+    /// United Arab Emirates Dirham (Fiat).
+    /// </summary>
+    [EnumMember(Value = "AED")]
+    AED = 15,
+    
+    /// <summary>
+    /// Chinese Yuan (Renminbi) (Fiat).
+    /// </summary>
+    [EnumMember(Value = "CNH")]
+    CNH = 16,
+    
+    /// <summary>
+    /// Hong Kong Dollar (Fiat).
+    /// </summary>
+    [EnumMember(Value = "HKD")]
+    HKD = 17,
+    
+    /// <summary>
+    /// Israeli Shekel (Fiat).
+    /// </summary>
+    [EnumMember(Value = "ILS")]
+    ILS = 18,
+    
+    /// <summary>
+    /// Japanese Yen (Fiat).
+    /// </summary>
+    [EnumMember(Value = "JPY")]
+    JPY = 19,
+    
+    /// <summary>
+    /// Mexican Peso (Fiat).
+    /// </summary>
+    [EnumMember(Value = "MXN")]
+    MXN = 20,
+    
+    /// <summary>
+    /// New Zealand Dollar (Fiat).
+    /// </summary>
+    [EnumMember(Value = "NZD")]
+    NZD = 21,
+    
+    /// <summary>
+    /// Saudi Riyal (Fiat).
+    /// </summary>
+    [EnumMember(Value = "SAR")]
+    SAR = 22,
+    
+    /// <summary>
+    /// Swedish Krona (Fiat).
+    /// </summary>
+    [EnumMember(Value = "SEK")]
+    SEK = 23,
+    
+    /// <summary>
+    /// Singapore Dollar (Fiat).
+    /// </summary>
+    [EnumMember(Value = "SGD")]
+    SGD = 24,
+    
+    /// <summary>
+    /// Turkish Lira (Fiat).
+    /// </summary>
+    [EnumMember(Value = "TRY")]
+    TRY = 25,
+    
+    /// <summary>
+    /// South African Rand (Fiat).
+    /// </summary>
+    [EnumMember(Value = "ZAR")]
+    ZAR = 26,
     
     // Start non-fiat currencies from 1000 to avoid conflicting with supplier mappings.
 

--- a/src/NoFrixion.MoneyMoov/Extensions/CurrencyExtensions.cs
+++ b/src/NoFrixion.MoneyMoov/Extensions/CurrencyExtensions.cs
@@ -21,22 +21,10 @@ namespace NoFrixion.MoneyMoov;
 public static class CurrencyExtensions
 {
     public static string GetCurrencySymbol(this CurrencyTypeEnum currency) =>
-    currency switch
-    {
-        CurrencyTypeEnum.BTC => Iso4217CurrencyTable.GetInfo(currency).Symbol,
-        CurrencyTypeEnum.GBP => Iso4217CurrencyTable.GetInfo(currency).Symbol,
-        CurrencyTypeEnum.EUR => Iso4217CurrencyTable.GetInfo(currency).Symbol,
-        CurrencyTypeEnum.USD => Iso4217CurrencyTable.GetInfo(currency).Symbol,
-        CurrencyTypeEnum.None => Iso4217CurrencyTable.GetInfo(currency).Symbol,
-        _ => "€"
-    };
+        Iso4217CurrencyTable.GetInfo(currency).Symbol ;
 
     public static bool IsFiat(this CurrencyTypeEnum currency) =>
-        currency switch
-        {
-            CurrencyTypeEnum.BTC => false,
-            _ => true
-        };
+        Iso4217CurrencyTable.GetInfo(currency).IsFiat;
 
     public static string Iso4217AlphaCode(this CurrencyTypeEnum currency) =>
         Iso4217CurrencyTable.GetInfo(currency).Iso4217AlphaCode;

--- a/src/NoFrixion.MoneyMoov/Models/Currency/CurrencyInfo.cs
+++ b/src/NoFrixion.MoneyMoov/Models/Currency/CurrencyInfo.cs
@@ -20,5 +20,6 @@ public record CurrencyInfo(
     string Iso4217AlphaCode,
     string Iso4217NumericCode,
     int Decimals,
-    string Symbol
+    string Symbol,
+    bool IsFiat
 );

--- a/test/MoneyMoov.UnitTests/Constants/Iso4217CurrencyTableTests.cs
+++ b/test/MoneyMoov.UnitTests/Constants/Iso4217CurrencyTableTests.cs
@@ -45,9 +45,9 @@ public class Iso4217CurrencyTableTests
     }
 
     [Fact]
-    public void GetInfo_Returns_Expected_Decimals_For_Isk_And_Btc()
+    public void GetInfo_Returns_Expected_Decimals_For_Jpy_And_Btc()
     {
-        Assert.Equal(0, Iso4217CurrencyTable.GetInfo(CurrencyTypeEnum.ISK).Decimals);
+        Assert.Equal(0, Iso4217CurrencyTable.GetInfo(CurrencyTypeEnum.JPY).Decimals);
         Assert.Equal(PaymentsConstants.BITCOIN_ROUNDING_DECIMAL_PLACES, Iso4217CurrencyTable.GetInfo(CurrencyTypeEnum.BTC).Decimals);
     }
 }

--- a/test/MoneyMoov.UnitTests/Extensions/CurrencyExtensionsTests.cs
+++ b/test/MoneyMoov.UnitTests/Extensions/CurrencyExtensionsTests.cs
@@ -22,7 +22,7 @@ public class CurrencyExtensionsTests
     [Theory]
     [InlineData(CurrencyTypeEnum.EUR, "EUR")]
     [InlineData(CurrencyTypeEnum.GBP, "GBP")]
-    [InlineData(CurrencyTypeEnum.ISK, "ISK")]
+    [InlineData(CurrencyTypeEnum.JPY, "JPY")]
     [InlineData(CurrencyTypeEnum.BTC, "BTC")]
     [InlineData(CurrencyTypeEnum.None, "NONE")]
     public void Iso4217AlphaCode_Returns_Expected_Value(CurrencyTypeEnum currency, string expectedCode)
@@ -33,7 +33,7 @@ public class CurrencyExtensionsTests
     [Theory]
     [InlineData(CurrencyTypeEnum.EUR, "978")]
     [InlineData(CurrencyTypeEnum.GBP, "826")]
-    [InlineData(CurrencyTypeEnum.ISK, "352")]
+    [InlineData(CurrencyTypeEnum.JPY, "392")]
     [InlineData(CurrencyTypeEnum.BTC, "")]
     [InlineData(CurrencyTypeEnum.None, "")]
     public void Iso4217NumericCode_Returns_Expected_Value(CurrencyTypeEnum currency, string expectedCode)
@@ -43,7 +43,7 @@ public class CurrencyExtensionsTests
 
     [Theory]
     [InlineData(CurrencyTypeEnum.EUR, 2)]
-    [InlineData(CurrencyTypeEnum.ISK, 0)]
+    [InlineData(CurrencyTypeEnum.JPY, 0)]
     [InlineData(CurrencyTypeEnum.BTC, 8)]
     [InlineData(CurrencyTypeEnum.None, 0)]
     public void DefaultDecimals_Returns_Expected_Value(CurrencyTypeEnum currency, int expectedDecimals)
@@ -51,10 +51,26 @@ public class CurrencyExtensionsTests
         Assert.Equal(expectedDecimals, currency.DefaultDecimals());
     }
 
-    [Fact]
-    public void GetCurrencySymbol_Returns_Legacy_Euro_Fallback_For_Other_Fiat_Currencies()
+    [Theory]
+    [InlineData(CurrencyTypeEnum.EUR, "€")]
+    [InlineData(CurrencyTypeEnum.GBP, "£")]
+    [InlineData(CurrencyTypeEnum.USD, "$")]
+    [InlineData(CurrencyTypeEnum.JPY, "¥")]
+    [InlineData(CurrencyTypeEnum.CHF, "CHF")]
+    [InlineData(CurrencyTypeEnum.None, "?")]
+    public void GetCurrencySymbol_Returns_Expected_Value(CurrencyTypeEnum currency, string expectedSymbol)
     {
-        Assert.Equal("€", CurrencyTypeEnum.DKK.GetCurrencySymbol());
-        Assert.Equal("€", CurrencyTypeEnum.CHF.GetCurrencySymbol());
+        Assert.Equal(expectedSymbol, currency.GetCurrencySymbol());
+    }
+
+    [Theory]
+    [InlineData(CurrencyTypeEnum.EUR, true)]
+    [InlineData(CurrencyTypeEnum.GBP, true)]
+    [InlineData(CurrencyTypeEnum.USD, true)]
+    [InlineData(CurrencyTypeEnum.BTC, false)]
+    [InlineData(CurrencyTypeEnum.None, true)]
+    public void GetIsFiatCurrency_Returns_Expected_Value(CurrencyTypeEnum currency, bool expectedFiatValue)
+    {
+        Assert.Equal(expectedFiatValue, currency.IsFiat());
     }
 }


### PR DESCRIPTION
Added the rest of the supported currencies for incoming payments and FX payouts.